### PR TITLE
Add CocoaPods subpec that doesn't add AdSupport (IDFA)

### DIFF
--- a/Branch.podspec
+++ b/Branch.podspec
@@ -21,7 +21,15 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
   s.platform     = :ios, '6.0'
   s.requires_arc = true
 
-  s.source_files = "Branch-SDK/Branch-SDK/*.{h,m}", "Branch-SDK/Fabric/*.h", "Branch-SDK/Branch-SDK/Requests/*.{h,m}"
+  s.subspec 'Core' do |core|
+    core.source_files = "Branch-SDK/Branch-SDK/*.{h,m}", "Branch-SDK/Fabric/*.h", "Branch-SDK/Branch-SDK/Requests/*.{h,m}"
 
-  s.frameworks = 'AdSupport', 'CoreTelephony', 'MobileCoreServices'
+    core.frameworks = 'AdSupport', 'CoreTelephony', 'MobileCoreServices'
+  end
+
+  s.subspec 'without-IDFA' do |idfa|
+    idfa.source_files = "Branch-SDK/Branch-SDK/*.{h,m}", "Branch-SDK/Fabric/*.h", "Branch-SDK/Branch-SDK/Requests/*.{h,m}"
+
+    idfa.frameworks = 'CoreTelephony', 'MobileCoreServices'
+  end
 end


### PR DESCRIPTION
As a developer I would like to be able to install the SDK using CocoaPods and without the AdSupport framework (IDFA).
In the docs you pin point correctly [how to achieve this](https://dev.branch.io/getting-started/sdk-integration-guide/guide/ios/#submitting-to-the-app-store).

I added a new subspec in the podspec that any developer will be able to use for installing the SDK without IDFA. This will allow us to keep the SDK updated easily.

For testing it you can include this line in a test project: `pod 'Branch/without-IDFA', git: 'https://github.com/ziogaschr/iOS-Deferred-Deep-Linking-SDK.git', :branch => 'cocoapod-without-idfa'`

p.s.: `idfa.source_files` at line 31 is needed as having only the `idfa. frameworks ` at line 33 is not sufficient.