### PR TITLE
add sanity checks to strong_match request url

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.m
@@ -112,8 +112,13 @@ NSInteger const ABOUT_30_DAYS_TIME_IN_SECONDS = 60 * 60 * 24 * 30;
     
     Class SFSafariViewControllerClass = NSClassFromString(@"SFSafariViewController");
     if (SFSafariViewControllerClass) {
-        UIViewController * safController = [[SFSafariViewControllerClass alloc] initWithURL:[NSURL URLWithString:urlString]];
+        NSURL *strongMatchUrl = [NSURL URLWithString:[urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+        if (!strongMatchUrl) {
+            self.requestInProgress = NO;
+            return;
+        }
         
+        UIViewController * safController = [[SFSafariViewControllerClass alloc] initWithURL:strongMatchUrl];
         self.secondWindow = [[UIWindow alloc] initWithFrame:[[[[UIApplication sharedApplication] windows] firstObject] bounds]];
         UIViewController *windowRootController = [[UIViewController alloc] init];
         self.secondWindow.rootViewController = windowRootController;


### PR DESCRIPTION
`NSURL` returns `nil` if the string is an invalid URL. If a partner uses a space in their app version, this would return `nil` for example. `SFSafariViewController` crashes if given a `nil` for a URL. This change encodes the request and ensure it fails gracefully if the URL is `nil` for any reason.

2 things worth checking that I am not sure how to check for: ensuring that an encoded request would work fine on the backend (the logs are fine) and implications on the request queue on the client when returning early. I set `self.requestInProgress = NO` but not sure if this is enough.

@aaustin @derrickstaten @scott-branchio 

