### PR TITLE
Fix retry code

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.m
@@ -101,6 +101,9 @@ void (^NSURLConnectionCompletionHandler) (NSURLResponse *response, NSData *respo
                 NSURLRequest *retryRequest = retryHandler(retryNumber);
                 [self genericHTTPRequest:retryRequest retryNumber:(retryNumber + 1) log:log callback:callback retryHandler:retryHandler];
             });
+            
+            // Do not continue on if retrying, else the callback will be called incorrectly
+            return;
         }
         else if (callback) {
             // Wrap up bad statuses w/ specific error messages
@@ -123,7 +126,7 @@ void (^NSURLConnectionCompletionHandler) (NSURLResponse *response, NSData *respo
         }
         dispatch_async(dispatch_get_main_queue(), ^{
             if (callback)
-            callback(serverResponse, error);
+                callback(serverResponse, error);
         });
     };
     


### PR DESCRIPTION
Please submit your PR against the `staging` branch.


@ahmednawar @derrickstaten When the retry code executes due to a 500
error code, we fall through and callback the block. This should not
happen and would lead to callbacks being executed multiple times. I
believe this to be the root cause of the crash when the credit service
went down last night.