### PR TITLE
Fix for Facebook calling openUrl from within the app

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -387,7 +387,7 @@ NSString * const BRANCH_PUSH_NOTIFICATION_PAYLOAD_KEY = @"branch";
         }
     }
     
-    [self initUserSessionAndCallCallback:YES];
+    [self initUserSessionAndCallCallback:!self.isInitialized];
     
     return handled;
 }


### PR DESCRIPTION
As reported in https://github.com/BranchMetrics/ios-branch-deep-linking/issues/370, Facebook is now calling openUrl any time from within the app to handle their new auth flow. This incorrectly will force Branch to call the callback block with the same current session parameters.

This change will prevent the callback block from executing if the session is already initialized. @ahmednawar @derrickstaten 