### PR TITLE
expose branch view header files in framework

### DIFF
--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -123,10 +123,10 @@
 		67486B8E1B93B48A0044D872 /* BNCStrongMatchHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 67486B8C1B93B48A0044D872 /* BNCStrongMatchHelper.m */; };
 		677F4CB51C1FB1910029F2B3 /* Branch-TestBed.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 677F4CB41C1FB0FA0029F2B3 /* Branch-TestBed.entitlements */; };
 		67F270891BA9FCFF002546A7 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */; settings = {ATTRIBUTES = (Required, ); }; };
-		7D4DAC211C8FA8C0008E37DB /* BranchView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D4DAC201C8FA8C0008E37DB /* BranchView.h */; };
+		7D4DAC211C8FA8C0008E37DB /* BranchView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D4DAC201C8FA8C0008E37DB /* BranchView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7D4DAC251C8FA908008E37DB /* BranchViewHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D4DAC221C8FA908008E37DB /* BranchViewHandler.m */; };
 		7D4DAC261C8FA908008E37DB /* BranchView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D4DAC231C8FA908008E37DB /* BranchView.m */; };
-		7D4DAC271C8FA908008E37DB /* BranchViewHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D4DAC241C8FA908008E37DB /* BranchViewHandler.h */; };
+		7D4DAC271C8FA908008E37DB /* BranchViewHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D4DAC241C8FA908008E37DB /* BranchViewHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7D58823A1CA1DF2700FF6358 /* BNCDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D5882391CA1DF2700FF6358 /* BNCDeviceInfo.m */; };
 		7E6B3B561AA42D0E005F45BF /* Branch_SDK_Functionality_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E6B3B551AA42D0E005F45BF /* Branch_SDK_Functionality_Tests.m */; };
 		9F4BE02E2EFA48B94EB8CEAD /* libPods-Branch-SDK-Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AA508DAFBC70E7B594A5D76C /* libPods-Branch-SDK-Tests.a */; };
@@ -613,11 +613,12 @@
 				54391A151BA249FA0061CB0F /* BranchCSSearchableItemAttributeSet.h in Headers */,
 				466B58791B17780A00A69EDE /* BNCConfig.h in Headers */,
 				E2546CDA1C82B164006AD5D2 /* BranchSDK.h in Headers */,
+				7D4DAC211C8FA8C0008E37DB /* BranchView.h in Headers */,
+				7D4DAC271C8FA908008E37DB /* BranchViewHandler.h in Headers */,
 				E214D4451CAF432C007FF922 /* FABAttributes.h in Headers */,
 				E214D4461CAF432C007FF922 /* FABKitProtocol.h in Headers */,
 				E214D4471CAF432C007FF922 /* Fabric.h in Headers */,
 				E214D4481CAF432C007FF922 /* Fabric+FABKits.h in Headers */,
-				7D4DAC271C8FA908008E37DB /* BranchViewHandler.h in Headers */,
 				54FF1F8D1BD1D4AE0004CE2E /* BranchUniversalObject.h in Headers */,
 				46946B9F1B2689A100627BCC /* BranchShortUrlSyncRequest.h in Headers */,
 				46946B9E1B2689A100627BCC /* BranchShortUrlRequest.h in Headers */,
@@ -637,7 +638,6 @@
 				46946BA41B2689A100627BCC /* BranchInstallRequest.h in Headers */,
 				46946B861B26898B00627BCC /* BranchSetIdentityRequest.h in Headers */,
 				466B58771B17780A00A69EDE /* BNCSystemObserver.h in Headers */,
-				7D4DAC211C8FA8C0008E37DB /* BranchView.h in Headers */,
 				46946B881B26899100627BCC /* BranchUserCompletedActionRequest.h in Headers */,
 				466B587A1B17780A00A69EDE /* BNCError.h in Headers */,
 				46946BA01B2689A100627BCC /* BranchCloseRequest.h in Headers */,

--- a/Branch.framework/Versions/A/Headers/BranchView.h
+++ b/Branch.framework/Versions/A/Headers/BranchView.h
@@ -1,0 +1,49 @@
+//
+//  BranchView.h
+//  Branch-TestBed
+//
+//  Created by Sojan P.R. on 3/4/16.
+//  Copyright © 2016 Branch Metrics. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+
+@interface BranchView : NSObject
+//-------- properties-------------------//
+/**
+ Unique ID for this Branch view
+ */
+@property (strong, nonatomic) NSString *branchViewID;
+/**
+ User or Branch action associated with the Branch view
+ */
+@property (strong, nonatomic) NSString *branchViewAction;
+/**
+ Number of times this Branch view can be used
+ */
+@property (nonatomic) NSInteger numOfUse;
+/**
+ Web url to for showing html content for the Branch View
+ */
+@property (strong, nonatomic) NSString *webUrl;
+/**
+ Html content for loading the web view
+ */
+@property (strong, nonatomic) NSString *webHtml;
+
+//---------- Methods---------------//
+/**
+ Initialises Branch View with the given dictionary
+ */
+- (id)initWithBranchView:(NSDictionary *)branchViewDict andActionName:(NSString *)actionName;
+/**
+ Check Branch view for usage limit
+ */
+- (BOOL)isAvailable;
+/**
+ update the usage count for this Branch view
+ */
+- (void)updateUsageCount;
+
+@end

--- a/Branch.framework/Versions/A/Headers/BranchViewHandler.h
+++ b/Branch.framework/Versions/A/Headers/BranchViewHandler.h
@@ -1,0 +1,42 @@
+//
+//  BNCViewHandler.h
+//  Branch-TestBed
+//
+//  Created by Sojan P.R. on 3/3/16.
+//  Copyright © 2016 Branch Metrics. All rights reserved.
+//
+
+#ifndef BranchViewHandler_h
+#define BranchViewHandler_h
+
+
+#endif /* BranchViewHandler_h */
+#import "BranchView.h"
+
+
+@protocol BranchViewControllerDelegate <NSObject>
+
+- (void)branchViewVisible:(NSString *)actionName withID:(NSString *)branchViewID;
+- (void)branchViewAccepted:(NSString *)actionName withID:(NSString *)branchViewID;
+- (void)branchViewCancelled:(NSString *)actionName withID:(NSString *)branchViewID;
+- (void)branchViewErrorCode:(NSInteger)errorCode message:(NSString *)errorMsg actionName:(NSString *)actionName withID:(NSString *)branchViewID;
+@end
+
+@interface BranchViewHandler : NSObject
+//---- Properties---------------//
+/**
+ Callback for Branch View events
+ */
+@property (nonatomic, assign) id  <BranchViewControllerDelegate> branchViewCallback;
+
+//-- Methods--------------------//
+/**
+ Gets the global instance for BranchViewHandler.
+ */
++ (BranchViewHandler *)getInstance;
+/**
+ Shows a Branch view for the given action if available
+ */
+- (BOOL)showBranchView:(NSString *)actionName withBranchViewDictionary:(NSDictionary*)branchViewDict andWithDelegate:(id)callback;
+
+@end


### PR DESCRIPTION
make Branch view header files public in the framework since our umbrella header for building modules imports it

