### PR TITLE
Fix for error handling of 400 errors.

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.m
@@ -118,10 +118,10 @@ void (^NSURLConnectionCompletionHandler) (NSURLResponse *response, NSData *respo
                 error = [NSError errorWithDomain:BNCErrorDomain code:BNCDuplicateResourceError userInfo:@{ NSLocalizedDescriptionKey: @"A resource with this identifier already exists" }];
             }
             else if (status >= 400) {
-                NSString *errorString = @"The request was invalid."
+                NSString *errorString = @"The request was invalid.";
                 
                 if ([serverResponse.data objectForKey:@"error"] && [[serverResponse.data objectForKey:@"error"] isKindOfClass:[NSString class]]) {
-                    errorString = [serverResponse.data objectForKey:@"error"]
+                    errorString = [serverResponse.data objectForKey:@"error"];
                 }
                 
                 error = [NSError errorWithDomain:BNCErrorDomain code:BNCBadRequestError userInfo:@{ NSLocalizedDescriptionKey: errorString }];

--- a/Branch-SDK/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.m
@@ -118,7 +118,11 @@ void (^NSURLConnectionCompletionHandler) (NSURLResponse *response, NSData *respo
                 error = [NSError errorWithDomain:BNCErrorDomain code:BNCDuplicateResourceError userInfo:@{ NSLocalizedDescriptionKey: @"A resource with this identifier already exists" }];
             }
             else if (status >= 400) {
-                NSString *errorString = [serverResponse.data objectForKey:@"error"] ?: @"The request was invalid.";
+                NSString *errorString = @"The request was invalid."
+                
+                if ([serverResponse.data objectForKey:@"error"] && [[serverResponse.data objectForKey:@"error"] isKindOfClass:[NSString class]]) {
+                    errorString = [serverResponse.data objectForKey:@"error"]
+                }
                 
                 error = [NSError errorWithDomain:BNCErrorDomain code:BNCBadRequestError userInfo:@{ NSLocalizedDescriptionKey: errorString }];
             }


### PR DESCRIPTION
One of the partners reported that there were cases that the object returned for key `error` was not a string but another object which led to a crash.

This fix will fallback to the default error string in such case.

@ahmednawar, please review.