### PR TITLE
Add missing frameworks to Podspec

### DIFF
--- a/Branch.podspec
+++ b/Branch.podspec
@@ -22,12 +22,12 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
   s.subspec 'Core' do |core|
     core.source_files = "Branch-SDK/Branch-SDK/*.{h,m}", "Branch-SDK/Branch-SDK/Requests/*.{h,m}", "Branch-SDK/Fabric/*.h"
     core.private_header_files = "Branch-SDK/Fabric/*.h"
-    core.frameworks = 'AdSupport', 'CoreTelephony', 'MobileCoreServices'
+    core.frameworks = 'AdSupport', 'CoreTelephony', 'CoreSpotlight', 'MobileCoreServices', 'SafariServices'
   end
 
   s.subspec 'without-IDFA' do |idfa|
     idfa.source_files = "Branch-SDK/Branch-SDK/*.{h,m}", "Branch-SDK/Branch-SDK/Requests/*.{h,m}", "Branch-SDK/Fabric/*.h"
     idfa.private_header_files = "Branch-SDK/Fabric/*.h"
-    idfa.frameworks = 'CoreTelephony', 'MobileCoreServices'
+    idfa.frameworks = 'CoreTelephony', 'CoreSpotlight', 'MobileCoreServices', 'SafariServices'
   end
 end


### PR DESCRIPTION
Hello,
first of all I think that Podspec is missing 2 frameworks that you advice to be used [here](https://dev.branch.io/getting-started/sdk-integration-guide/advanced/ios/).
Let me know if you've done this by intention.

Also I am not sure, but this might fix #400. We are not using the feature @rafaellage wants to use, so please check.

The reason we created this PR is because of the following flow:

1. User click on a bnc.lt link, while App is not installed in phone
2. App Store opens and user installs the App
3. User opens the App but no data are being received from Branch.io

Note: We are installing App using `pod 'Branch/without-IDFA'` which means without `AdSupport`. Which is causing trouble to your flow, although on the other hand you say that App will matched 100% sure with use of `SafariServices`.