### PR TITLE
Fix Branch & Mopub Fabric header conflict

### DIFF
--- a/Branch.podspec
+++ b/Branch.podspec
@@ -16,6 +16,7 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
   s.license          = 'Proprietary'
   s.author           = { "Branch" => "support@branch.io" }
   s.source           = { :git => "https://github.com/BranchMetrics/iOS-Deferred-Deep-Linking-SDK.git", :tag => s.version.to_s }
+  s.private_header_files = "Branch-SDK/Fabric/*.h"
   s.platform     = :ios, '6.0'
   s.requires_arc = true
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ pod "Branch"
 To integrate Branch into your project using Carthage add the following to your `Cartfile`:
 
 ```ruby
-github "BranchMetrics/iOS-Deferred-Deep-Linking-SDK"
+github "BranchMetrics/ios-branch-deep-linking"
 ```
 
 ### Download the Raw Files


### PR DESCRIPTION
Fixes inclusion of Branch and Mopub when using Cocoapods
Relates to #332 

example project with broken include and fix [here](https://dl.dropboxusercontent.com/u/1466870/BranchIO-Mopub-Conflict.zip)