### PR TITLE
retrieve content type in BUO

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.m
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.m
@@ -327,6 +327,9 @@
         universalObject.currency = dictionary[BNCPurchaseCurrency];
     }
     
+    if (dictionary[BRANCH_LINK_DATA_KEY_CONTENT_TYPE]) {
+        universalObject.type = dictionary[BRANCH_LINK_DATA_KEY_CONTENT_TYPE];
+    }
     return universalObject;
 }
 

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -26,7 +26,7 @@ NSString *user_id1 = @"abe@emailaddress.io";
 NSString *user_id2 = @"ben@emailaddress.io";
 NSString *live_key = @"live_key";
 NSString *test_key = @"test_key";
-
+NSString *type = @"some type";
 
 @interface ViewController ()
 
@@ -57,6 +57,7 @@ NSString *test_key = @"test_key";
     _branchUniversalObject.imageUrl = imageUrl;
     _branchUniversalObject.price = 1000;
     _branchUniversalObject.currency = @"$";
+    _branchUniversalObject.type = type;
     [_branchUniversalObject addMetadataKey:@"deeplink_text" value:[NSString stringWithFormat:
                                                                    @"This text was embedded as data in a Branch link with the following characteristics:\n\n  canonicalUrl: %@\n  title: %@\n  contentDescription: %@\n  imageUrl: %@\n", canonicalUrl, contentTitle, contentDescription, imageUrl]];
     [self refreshRewardPoints];


### PR DESCRIPTION
add missing $content_type to the BUO data when parsing a dictionary. This was reported in #419 

@aaustin 

