### PR TITLE
Block other requests until init finished

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1109,7 +1109,7 @@ NSString * const BNCShareCompletedEvent = @"Share Completed";
 - (void)processNextQueueItem {
     dispatch_semaphore_wait(self.processing_sema, DISPATCH_TIME_FOREVER);
     
-    if (self.networkCount == 0 && self.requestQueue.size > 0) {
+    if (self.networkCount == 0 && self.requestQueue.size > 0 && !self.preferenceHelper.shouldWaitForInit) {
         self.networkCount = 1;
         dispatch_semaphore_signal(self.processing_sema);
         


### PR DESCRIPTION
Before this change, it was possible for other requests to be called before init was called. I believe this would cause some types of requests to fail and possibly crash., especially on some of the other platforms like Cordova, where the lifecycle management is quite wonky.
