### PR TITLE
AIS-40: Brtt encoding

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
@@ -230,7 +230,7 @@ static const short _base64DecodingTable[256] = {
             value = [BNCEncodingUtils encodeArrayToJsonString:obj];
             string = NO;
         }
-        else if ([obj isKindOfClass:[NSDictionary class]]) {
+        else if ([obj isKindOfClass:[NSDictionary class]] || [obj isKindOfClass:[NSMutableDictionary class]]) {
             value = [BNCEncodingUtils encodeDictionaryToJsonString:obj];
             string = NO;
         }
@@ -297,7 +297,7 @@ static const short _base64DecodingTable[256] = {
             value = [BNCEncodingUtils encodeArrayToJsonString:obj];
             string = NO;
         }
-        else if ([obj isKindOfClass:[NSDictionary class]]) {
+        else if ([obj isKindOfClass:[NSDictionary class]] || [obj isKindOfClass:[NSMutableDictionary class]]) {
             value = [BNCEncodingUtils encodeDictionaryToJsonString:obj];
             string = NO;
         }


### PR DESCRIPTION
This handles the encoding errors I was getting for brtt. The instrumentation dictionary is mutable and this wasn't one of the classes handled in the encoding method.

@aaustin 

