### PR TITLE
Support separate keys for Fabric config

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -185,6 +185,9 @@ static NSString * const BNC_BRANCH_FABRIC_APP_KEY_KEY = @"branch_key";
             if ([ret isKindOfClass:[NSString class]]) {
                 self.branchKey = ret;
             }
+            else if ([ret isKindOfClass:[NSDictionary class]]) {
+                self.branchKey = isLive ? ret[@"live"] : ret[@"test"];
+            }
         }
     }
     


### PR DESCRIPTION
This is in response to https://github.com/BranchMetrics/ios-branch-deep-linking/issues/429. It supports the dictionary based key storage method in the Fabric config.

@derrickstaten 

