### PR TITLE
Clear timer on activation

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1094,6 +1094,7 @@ NSString * const BNCShareCompletedEvent = @"Share Completed";
 #pragma mark - Application State Change methods
 
 - (void)applicationDidBecomeActive {
+    [self clearTimer];
     if (!self.isInitialized && !self.preferenceHelper.shouldWaitForInit && ![self.requestQueue containsInstallOrOpen]) {
         [self initUserSessionAndCallCallback:YES];
     }


### PR DESCRIPTION
This resolves a potential lifecycle edge case where applicationDidBecomeActive handler is called before the scheduled “callClose” happens (this timer is setup on applicationWillResignActive handler and it is scheduled to happen half a second after). In this case, the SDK will initialize and then be de-initialized when callClose triggers, causing any subsequent call to Branch’s methods will make the application to crash with the error: “Branch SDK Error: making request before init succeeded!".

We've been unable to reproduce this but logically, it is possible.

@derrickstaten 

