### PR TITLE
Fix unknown credits crash

### DIFF
--- a/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
@@ -49,7 +49,7 @@
     if ([responseKeys count] && ([response.data isKindOfClass:[NSDictionary class]] || [response.data isKindOfClass:[NSMutableDictionary class]])) {
         
         for (NSString *key in response.data) {
-            if (!key) { continue; }
+            if (![key isKindOfClass:[NSString class]]) { continue; }
             
             NSInteger credits = [preferenceHelper getCreditCountForBucket:key];
             if (response.data[key] && [response.data[key] respondsToSelector:@selector(integerValue)]) {
@@ -64,7 +64,7 @@
             [preferenceHelper setCreditCount:credits forBucket:key];
         }
         for(NSString *key in storedKeys) {
-            if (!key) { continue; }
+            if (![key isKindOfClass:[NSString class]]) { continue; }
 
             if(![response.data objectForKey:key]) {
                 [preferenceHelper removeCreditCountForBucket:key];

--- a/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
@@ -46,16 +46,20 @@
     NSArray *responseKeys = [response.data allKeys];
     NSArray *storedKeys = [currentCreditDictionary allKeys];
 
-    if ([responseKeys count]) {
+    if ([responseKeys count] && ([response.data isKindOfClass:[NSDictionary class]] || [response.data isKindOfClass:[NSMutableDictionary class]])) {
+        
         for (NSString *key in response.data) {
-             NSInteger credits = [response.data[key] integerValue];
+            NSInteger credits = [preferenceHelper getCreditCountForBucket:key];
+            if (response.data[key] && [response.data[key] respondsToSelector:@selector(integerValue)]) {
+                credits = [response.data[key] integerValue];
+            }
 
-             BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-             if (credits != [preferenceHelper getCreditCountForBucket:key]) {
-                 hasUpdated = YES;
-             }
+            BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+            if (credits != [preferenceHelper getCreditCountForBucket:key]) {
+                hasUpdated = YES;
+            }
 
-             [preferenceHelper setCreditCount:credits forBucket:key];
+            [preferenceHelper setCreditCount:credits forBucket:key];
         }
         for(NSString *key in storedKeys) {
             if(![response.data objectForKey:key]) {

--- a/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
@@ -49,6 +49,8 @@
     if ([responseKeys count] && ([response.data isKindOfClass:[NSDictionary class]] || [response.data isKindOfClass:[NSMutableDictionary class]])) {
         
         for (NSString *key in response.data) {
+            if (!key) { continue; }
+            
             NSInteger credits = [preferenceHelper getCreditCountForBucket:key];
             if (response.data[key] && [response.data[key] respondsToSelector:@selector(integerValue)]) {
                 credits = [response.data[key] integerValue];
@@ -62,6 +64,8 @@
             [preferenceHelper setCreditCount:credits forBucket:key];
         }
         for(NSString *key in storedKeys) {
+            if (!key) { continue; }
+
             if(![response.data objectForKey:key]) {
                 [preferenceHelper removeCreditCountForBucket:key];
                 hasUpdated = YES;


### PR DESCRIPTION
We have reports of a rare but unreproducible crash in `loadRewards`. The crash report indicated that there was a `Fatal Exception: NSInvalidArgumentException` on line 51. This pull request adds extensive type checking to ensure arguments are valid.

@agrimn @derrickstaten 