### PR TITLE
Share Sheet Swift Crash

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.m
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.m
@@ -182,7 +182,12 @@
     // Log share initiated event
     [self userCompletedAction:BNCShareInitiatedEvent];
     UIActivityItemProvider *itemProvider = [self getBranchActivityItemWithLinkProperties:linkProperties];
-    NSMutableArray *items = [NSMutableArray arrayWithObject:itemProvider];
+    NSMutableArray *items;
+    if (itemProvider) {
+        items = [NSMutableArray arrayWithObject:itemProvider];
+    } else {
+        items = [[NSMutableArray alloc] init];
+    }
     if (shareText) {
         [items insertObject:shareText atIndex:0];
     }


### PR DESCRIPTION
Adding  NSInvalidArg pprotection.

Seems swift can return nil for UIActivityViewController  on initializing with place holder from issue reported below
https://github.com/BranchMetrics/ios-branch-deep-linking/issues/461
@aaustin @derrickstaten 
