### PR TITLE
AIS-83 add notes to the list of scraping channels

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchActivityItemProvider.m
+++ b/Branch-SDK/Branch-SDK/BranchActivityItemProvider.m
@@ -72,9 +72,11 @@
         channel = [self.delegate activityItemOverrideChannelForChannel:channel];
     }
     
-    // Because Facebook immediately scrapes URLs, we add an additional parameter to the existing list, telling the backend to ignore the first click
-    if ([channel isEqualToString:@"facebook"] || [channel isEqualToString:@"twitter"]  || [channel isEqualToString:@"com.tinyspeck.chatlyio.share"] || [channel isEqualToString:@"com.apple.mobilenotes.SharingExtension"]) {
-        return [NSURL URLWithString:[[Branch getInstance] getShortURLWithParams:params andTags:tags andChannel:channel andFeature:feature andStage:stage andCampaign:campaign andAlias:alias ignoreUAString:self.userAgentString forceLinkCreation:YES]];
+    // Because Facebook et al immediately scrape URLs, we add an additional parameter to the existing list, telling the backend to ignore the first click
+    NSArray *scrapers = @[@"facebook", @"twitter", @"com.tinyspeck.chatlyio.share", @"com.apple.mobilenotes.SharingExtension"];
+    for (NSString *scraper in scrapers) {
+        if ([channel isEqualToString:scraper])
+            return [NSURL URLWithString:[[Branch getInstance] getShortURLWithParams:params andTags:tags andChannel:channel andFeature:feature andStage:stage andCampaign:campaign andAlias:alias ignoreUAString:self.userAgentString forceLinkCreation:YES]];
     }
     return [NSURL URLWithString:[[Branch getInstance] getShortURLWithParams:params andTags:tags andChannel:channel andFeature:feature andStage:stage andCampaign:campaign andAlias:alias ignoreUAString:nil forceLinkCreation:YES]];
 }


### PR DESCRIPTION
Notes (iOS 9 and 10) also scrapes the link upon sharing similar to Facebook et al. This PR adds it to the list of scraping channels to ignore the first click.

@derrickstaten @aaustin @E-B-Smith 

