### PR TITLE
Fixed userCompletion crash due to nil values.

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.m
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.m
@@ -74,12 +74,12 @@
 - (void)userCompletedAction:(NSString *)action {
     NSMutableDictionary *actionPayload = [[NSMutableDictionary alloc] init];
     NSDictionary *linkParams = [self getParamsForServerRequest];
-    actionPayload[BNCCanonicalIdList] = @[self.canonicalIdentifier];
-    actionPayload[self.canonicalIdentifier] = linkParams;
-    
-    [[Branch getInstance] userCompletedAction:action withState:actionPayload];
-    if (self.automaticallyListOnSpotlight && [action isEqualToString:BNCRegisterViewEvent]) {
-        [self listOnSpotlight];
+    if (self.canonicalIdentifier && linkParams) {
+        actionPayload[BNCCanonicalIdList] = @[self.canonicalIdentifier];
+        actionPayload[self.canonicalIdentifier] = linkParams;
+        [[Branch getInstance] userCompletedAction:action withState:actionPayload];
+        if (self.automaticallyListOnSpotlight && [action isEqualToString:BNCRegisterViewEvent])
+            [self listOnSpotlight];
     }
 }
 

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -129,11 +129,17 @@
 // Helper method
 - (void)registerForPushNotifications:(UIApplication *)application {
     if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
-        [application registerUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:(UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge) categories:nil]];
+        [application registerUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:
+            (UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge)
+                categories:nil]];
         [application registerForRemoteNotifications];
-    }
-    else {
-        [application registerForRemoteNotificationTypes: (UIRemoteNotificationTypeNewsstandContentAvailability| UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
+    } else {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        [application registerForRemoteNotificationTypes:
+            (UIRemoteNotificationTypeNewsstandContentAvailability| UIRemoteNotificationTypeBadge |
+                UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
+        #pragma clang diagnostic push
     }
 }
 


### PR DESCRIPTION
Please submit your PR against the `staging` branch.

* Suppressed warnings for deprecated push notification types in TestBed
* Fixed crash bug in - (void)userCompletedAction:(NSString *)action (AIS-91)
