### PR TITLE
do not send brtt info in GET requests

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
@@ -244,7 +244,7 @@ static const short _base64DecodingTable[256] = {
         }
         else {
             // If this type is not a known type, don't attempt to encode it.
-            NSLog(@"Cannot encode value for key %@, type is in list of accepted types", key);
+            NSLog(@"[encodeDictionaryToJsonString] Cannot encode value for key %@, type is not in list of accepted types", key);
             continue;
         }
         
@@ -311,7 +311,7 @@ static const short _base64DecodingTable[256] = {
         }
         else {
             // If this type is not a known type, don't attempt to encode it.
-            NSLog(@"Cannot encode value %@, type is not in list of accepted types", obj);
+            NSLog(@"[encodedArray] Cannot encode value %@, type is not in list of accepted types", obj);
             continue;
         }
         
@@ -365,7 +365,7 @@ static const short _base64DecodingTable[256] = {
             }
             else {
                 // If this type is not a known type, don't attempt to encode it.
-                NSLog(@"Cannot encode value %@, type is in not list of accepted types", obj);
+                NSLog(@"[encodeDictionaryToQueryString] Cannot encode value %@, type is not in list of accepted types", obj);
                 continue;
             }
             

--- a/Branch-SDK/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.m
@@ -191,8 +191,10 @@ NSString *requestEndpoint;
 #pragma mark - Internals
 
 - (NSURLRequest *)prepareGetRequest:(NSDictionary *)params url:(NSString *)url key:(NSString *)key retryNumber:(NSInteger)retryNumber log:(BOOL)log {
-    NSDictionary *preparedParams = [self prepareParamDict:params key:key retryNumber:retryNumber];
+    NSMutableDictionary *preparedParams = [[self prepareParamDict:params key:key retryNumber:retryNumber] mutableCopy];
     
+    // explicitly remove instrumentation info from GET requests. They are only meant to be sent in POST requests.
+    [preparedParams removeObjectForKey:BRANCH_REQUEST_KEY_INSTRUMENTATION];
     NSString *requestUrlString = [NSString stringWithFormat:@"%@%@", url, [BNCEncodingUtils encodeDictionaryToQueryString:preparedParams]];
     
     if (log) {
@@ -243,7 +245,9 @@ NSString *requestEndpoint;
     NSMutableDictionary *metadata = [[NSMutableDictionary alloc] init];
     [metadata addEntriesFromDictionary:self.preferenceHelper.requestMetadataDictionary];
     [metadata addEntriesFromDictionary:fullParamDict[BRANCH_REQUEST_KEY_STATE]];
-    fullParamDict[BRANCH_REQUEST_KEY_STATE] = metadata;
+    if (metadata.count) {
+        fullParamDict[BRANCH_REQUEST_KEY_STATE] = metadata;
+    }
     if (self.preferenceHelper.instrumentationDictionary.count) {
         fullParamDict[BRANCH_REQUEST_KEY_INSTRUMENTATION] = self.preferenceHelper.instrumentationDictionary;
     }


### PR DESCRIPTION
We are still getting encoding errors for brtt if we are sending GET requests because we don't support encoding dictionaries to query strings.

After a discussion with brian, we decided not to send brtt info in GET requests. Another error comes up because we also send a metadata dictionary in all requests even if it's empty which results in an encoding error as well. This PR changes that to only send metadata if it contains data.

@aaustin @derrickstaten @E-B-Smith 

