### PR TITLE
Xcode 7 support

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCDeviceInfo.m
+++ b/Branch-SDK/Branch-SDK/BNCDeviceInfo.m
@@ -6,11 +6,14 @@
 //  Copyright © 2016 Branch Metrics. All rights reserved.
 //
 
+
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "BNCDeviceInfo.h"
 #import "BNCPreferenceHelper.h"
 #import "BNCSystemObserver.h"
+#import "BNCXcode7Support.h"
+
 
 @interface BNCDeviceInfo()
 
@@ -74,8 +77,9 @@ static BNCDeviceInfo *bncDeviceInfo;
 
     } else {
 
-        self.country = [NSLocale currentLocale].countryCode;
-        self.language = [NSLocale currentLocale].languageCode;
+        NSLocale *locale = [NSLocale currentLocale];
+        self.country = [locale countryCode];
+        self.language = [locale languageCode ];
 
     }
 

--- a/Branch-SDK/Branch-SDK/BNCXcode7Support.h
+++ b/Branch-SDK/Branch-SDK/BNCXcode7Support.h
@@ -1,0 +1,23 @@
+//
+//  BNCXcode7Support.h
+//  Branch-TestBed
+//
+//  Created by Edward on 10/26/16.
+//  Copyright © 2016 Branch Metrics. All rights reserved.
+//
+
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 100000
+#warning Compiling with Xcode 7 support
+
+
+#import <Foundation/Foundation.h>
+
+
+@interface NSLocale (BranchXcode7Support)
+- (NSString*) countryCode;
+- (NSString*) languageCode;
+@end
+
+
+#endif

--- a/Branch-SDK/Branch-SDK/BNCXcode7Support.m
+++ b/Branch-SDK/Branch-SDK/BNCXcode7Support.m
@@ -1,0 +1,16 @@
+//
+//  BNCXcode7Support.m
+//  Branch-TestBed
+//
+//  Created by Edward on 10/26/16.
+//  Copyright © 2016 Branch Metrics. All rights reserved.
+//
+
+
+#import "BNCXcode7Support.h"
+
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 100000
+//  Usually nothing goes here.
+#endif
+

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		46DC40801B2B84CD00D2D203 /* BranchShortUrlRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46DC407F1B2B84CD00D2D203 /* BranchShortUrlRequestTests.m */; };
 		46FD92BA1AE7E8F80012E78F /* BNCSystemObserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46FD92B91AE7E8F80012E78F /* BNCSystemObserverTests.m */; };
 		46FFCF171ACC321A00039CE0 /* BNCEncodingUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46FFCF161ACC321A00039CE0 /* BNCEncodingUtilsTests.m */; };
+		4D8999EC1DC108FF00F7EE0A /* BNCXcode7Support.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D8999EA1DC108FF00F7EE0A /* BNCXcode7Support.h */; };
+		4D8999ED1DC108FF00F7EE0A /* BNCXcode7Support.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D8999EB1DC108FF00F7EE0A /* BNCXcode7Support.m */; };
 		54391A151BA249FA0061CB0F /* BranchCSSearchableItemAttributeSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 54391A131BA249FA0061CB0F /* BranchCSSearchableItemAttributeSet.h */; };
 		54391A161BA249FA0061CB0F /* BranchCSSearchableItemAttributeSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 54391A141BA249FA0061CB0F /* BranchCSSearchableItemAttributeSet.m */; };
 		54FF1F8D1BD1D4AE0004CE2E /* BranchUniversalObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 54FF1F8B1BD1D4AE0004CE2E /* BranchUniversalObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -206,6 +208,8 @@
 		46DC407F1B2B84CD00D2D203 /* BranchShortUrlRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchShortUrlRequestTests.m; sourceTree = "<group>"; };
 		46FD92B91AE7E8F80012E78F /* BNCSystemObserverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCSystemObserverTests.m; sourceTree = "<group>"; };
 		46FFCF161ACC321A00039CE0 /* BNCEncodingUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCEncodingUtilsTests.m; sourceTree = "<group>"; };
+		4D8999EA1DC108FF00F7EE0A /* BNCXcode7Support.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCXcode7Support.h; sourceTree = "<group>"; };
+		4D8999EB1DC108FF00F7EE0A /* BNCXcode7Support.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCXcode7Support.m; sourceTree = "<group>"; };
 		54391A131BA249FA0061CB0F /* BranchCSSearchableItemAttributeSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchCSSearchableItemAttributeSet.h; sourceTree = "<group>"; };
 		54391A141BA249FA0061CB0F /* BranchCSSearchableItemAttributeSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchCSSearchableItemAttributeSet.m; sourceTree = "<group>"; };
 		54FF1F8B1BD1D4AE0004CE2E /* BranchUniversalObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchUniversalObject.h; sourceTree = "<group>"; };
@@ -524,6 +528,8 @@
 				7D5882391CA1DF2700FF6358 /* BNCDeviceInfo.m */,
 				E2133B711D0125EF00763049 /* BNCFabricAnswers.h */,
 				E2133B741D01477200763049 /* BNCFabricAnswers.m */,
+				4D8999EA1DC108FF00F7EE0A /* BNCXcode7Support.h */,
+				4D8999EB1DC108FF00F7EE0A /* BNCXcode7Support.m */,
 			);
 			name = "Branch-SDK";
 			path = "../Branch-SDK/Branch-SDK";
@@ -626,6 +632,7 @@
 				466B587F1B17780A00A69EDE /* BNCEncodingUtils.h in Headers */,
 				460F4FA71B618A38002E84D6 /* BranchSpotlightUrlRequest.h in Headers */,
 				54FF1F911BD1DC320004CE2E /* BranchLinkProperties.h in Headers */,
+				4D8999EC1DC108FF00F7EE0A /* BNCXcode7Support.h in Headers */,
 				67486B8D1B93B48A0044D872 /* BNCStrongMatchHelper.h in Headers */,
 				46946BA31B2689A100627BCC /* BranchOpenRequest.h in Headers */,
 				46946BA41B2689A100627BCC /* BranchInstallRequest.h in Headers */,
@@ -833,6 +840,7 @@
 				463F0A3C1B20A663004235D2 /* BranchShortUrlRequest.m in Sources */,
 				7D4DAC251C8FA908008E37DB /* BranchViewHandler.m in Sources */,
 				466B58591B17779C00A69EDE /* BNCPreferenceHelper.m in Sources */,
+				4D8999ED1DC108FF00F7EE0A /* BNCXcode7Support.m in Sources */,
 				466B585B1B17779C00A69EDE /* BNCServerInterface.m in Sources */,
 				463F0A411B20A663004235D2 /* BranchOpenRequest.m in Sources */,
 				463F0A341B20A663004235D2 /* BranchUserCompletedActionRequest.m in Sources */,

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -58,7 +58,6 @@
             error:&error];
     if (error) {
         NSLog(@"Error creating URLForPrefsDirectory: %@.", error);
-        return nil;
     }
     URL = [URL URLByAppendingPathComponent:@"io.branch"];
 

--- a/carthage-files/BranchSDK.xcodeproj/project.pbxproj
+++ b/carthage-files/BranchSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D19C1C21DC110FB008D8B38 /* BNCXcode7Support.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D19C1C01DC110FA008D8B38 /* BNCXcode7Support.h */; };
+		4D19C1C31DC110FB008D8B38 /* BNCXcode7Support.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D19C1C11DC110FB008D8B38 /* BNCXcode7Support.m */; };
 		7DA3BF1D1D889CE500CA8AE0 /* BranchContentDiscoverer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DA3BF171D889CE500CA8AE0 /* BranchContentDiscoverer.m */; };
 		7DA3BF1E1D889CE500CA8AE0 /* BranchContentDiscoverer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DA3BF181D889CE500CA8AE0 /* BranchContentDiscoverer.h */; };
 		7DA3BF1F1D889CE500CA8AE0 /* BranchContentDiscoveryManifest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DA3BF191D889CE500CA8AE0 /* BranchContentDiscoveryManifest.h */; };
@@ -90,6 +92,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4D19C1C01DC110FA008D8B38 /* BNCXcode7Support.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCXcode7Support.h; sourceTree = "<group>"; };
+		4D19C1C11DC110FB008D8B38 /* BNCXcode7Support.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCXcode7Support.m; sourceTree = "<group>"; };
 		7DA3BF171D889CE500CA8AE0 /* BranchContentDiscoverer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchContentDiscoverer.m; sourceTree = "<group>"; };
 		7DA3BF181D889CE500CA8AE0 /* BranchContentDiscoverer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoverer.h; sourceTree = "<group>"; };
 		7DA3BF191D889CE500CA8AE0 /* BranchContentDiscoveryManifest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoveryManifest.h; sourceTree = "<group>"; };
@@ -196,12 +200,7 @@
 		E230A1141D03DB9E006181D8 /* Branch-SDK */ = {
 			isa = PBXGroup;
 			children = (
-				7DA3BF171D889CE500CA8AE0 /* BranchContentDiscoverer.m */,
-				7DA3BF181D889CE500CA8AE0 /* BranchContentDiscoverer.h */,
-				7DA3BF191D889CE500CA8AE0 /* BranchContentDiscoveryManifest.h */,
-				7DA3BF1A1D889CE500CA8AE0 /* BranchContentDiscoveryManifest.m */,
-				7DA3BF1B1D889CE500CA8AE0 /* BranchContentPathProperties.h */,
-				7DA3BF1C1D889CE500CA8AE0 /* BranchContentPathProperties.m */,
+				E2B9477A1D15E31700F2270D /* BNCCallbacks.h */,
 				E230A1151D03DB9E006181D8 /* BNCConfig.h */,
 				E230A1161D03DB9E006181D8 /* BNCContentDiscoveryManager.h */,
 				E230A1171D03DB9E006181D8 /* BNCContentDiscoveryManager.m */,
@@ -211,9 +210,10 @@
 				E230A11B1D03DB9E006181D8 /* BNCEncodingUtils.m */,
 				E230A11C1D03DB9E006181D8 /* BNCError.h */,
 				E230A11D1D03DB9E006181D8 /* BNCError.m */,
+				E2B9477C1D15E3C100F2270D /* BNCFabricAnswers.h */,
+				E2B9477D1D15E3C100F2270D /* BNCFabricAnswers.m */,
 				E230A11E1D03DB9E006181D8 /* BNCLinkCache.h */,
 				E230A11F1D03DB9E006181D8 /* BNCLinkCache.m */,
-				E2B9477A1D15E31700F2270D /* BNCCallbacks.h */,
 				E230A1201D03DB9E006181D8 /* BNCLinkData.h */,
 				E230A1211D03DB9E006181D8 /* BNCLinkData.m */,
 				E230A1221D03DB9E006181D8 /* BNCPreferenceHelper.h */,
@@ -222,14 +222,14 @@
 				E230A1251D03DB9E006181D8 /* BNCServerInterface.m */,
 				E230A1261D03DB9E006181D8 /* BNCServerRequestQueue.h */,
 				E230A1271D03DB9E006181D8 /* BNCServerRequestQueue.m */,
-				E2B9477C1D15E3C100F2270D /* BNCFabricAnswers.h */,
-				E2B9477D1D15E3C100F2270D /* BNCFabricAnswers.m */,
 				E230A1281D03DB9E006181D8 /* BNCServerResponse.h */,
 				E230A1291D03DB9E006181D8 /* BNCServerResponse.m */,
 				E230A12A1D03DB9E006181D8 /* BNCStrongMatchHelper.h */,
 				E230A12B1D03DB9E006181D8 /* BNCStrongMatchHelper.m */,
 				E230A12C1D03DB9E006181D8 /* BNCSystemObserver.h */,
 				E230A12D1D03DB9E006181D8 /* BNCSystemObserver.m */,
+				4D19C1C01DC110FA008D8B38 /* BNCXcode7Support.h */,
+				4D19C1C11DC110FB008D8B38 /* BNCXcode7Support.m */,
 				E230A12E1D03DB9E006181D8 /* Branch-SDK-Prefix.pch */,
 				E230A12F1D03DB9E006181D8 /* Branch.h */,
 				E230A1301D03DB9E006181D8 /* Branch.m */,
@@ -237,6 +237,12 @@
 				E230A1321D03DB9E006181D8 /* BranchActivityItemProvider.m */,
 				E230A1331D03DB9E006181D8 /* BranchConstants.h */,
 				E230A1341D03DB9E006181D8 /* BranchConstants.m */,
+				7DA3BF181D889CE500CA8AE0 /* BranchContentDiscoverer.h */,
+				7DA3BF171D889CE500CA8AE0 /* BranchContentDiscoverer.m */,
+				7DA3BF191D889CE500CA8AE0 /* BranchContentDiscoveryManifest.h */,
+				7DA3BF1A1D889CE500CA8AE0 /* BranchContentDiscoveryManifest.m */,
+				7DA3BF1B1D889CE500CA8AE0 /* BranchContentPathProperties.h */,
+				7DA3BF1C1D889CE500CA8AE0 /* BranchContentPathProperties.m */,
 				E230A1351D03DB9E006181D8 /* BranchCSSearchableItemAttributeSet.h */,
 				E230A1361D03DB9E006181D8 /* BranchCSSearchableItemAttributeSet.m */,
 				E230A1371D03DB9E006181D8 /* BranchDeepLinkingController.h */,
@@ -358,6 +364,7 @@
 				E230A16D1D03DB9E006181D8 /* BNCContentDiscoveryManager.h in Headers */,
 				E230A1711D03DB9E006181D8 /* BNCEncodingUtils.h in Headers */,
 				E230A1981D03DB9E006181D8 /* BNCServerRequest.h in Headers */,
+				4D19C1C21DC110FB008D8B38 /* BNCXcode7Support.h in Headers */,
 				E230A1AC1D03DB9E006181D8 /* BranchRedeemRewardsRequest.h in Headers */,
 				E230A1AE1D03DB9E006181D8 /* BranchRegisterViewRequest.h in Headers */,
 				E230A18F1D03DB9E006181D8 /* BranchLinkProperties.h in Headers */,
@@ -459,6 +466,7 @@
 				E230A1721D03DB9E006181D8 /* BNCEncodingUtils.m in Sources */,
 				E230A1891D03DB9E006181D8 /* BranchActivityItemProvider.m in Sources */,
 				E230A1AF1D03DB9E006181D8 /* BranchRegisterViewRequest.m in Sources */,
+				4D19C1C31DC110FB008D8B38 /* BNCXcode7Support.m in Sources */,
 				E230A19F1D03DB9E006181D8 /* BranchCreditHistoryRequest.m in Sources */,
 				E230A1B91D03DB9F006181D8 /* BranchUserCompletedActionRequest.m in Sources */,
 				E230A19D1D03DB9E006181D8 /* BranchCloseRequest.m in Sources */,


### PR DESCRIPTION
I added a dummy category on NSLocale so that iOS 10 code will compile on Xcode 7.

I've confirmed that this patch compiles with both Xcode 7 and Xcode 8.
@aaustin @ahmednawar 