### PR TITLE
Fabric version fix ais 102

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -177,18 +177,25 @@ static NSString * const BNC_BRANCH_FABRIC_APP_KEY_KEY = @"branch_key";
         else if ([ret isKindOfClass:[NSDictionary class]]) {
             self.branchKey = isLive ? ret[@"live"] : ret[@"test"];
         }
-    } else {
-        Class fabric = NSClassFromString(@"Fabric");
         
-        if (fabric) {
+    } else {
+
+        Class fabric = NSClassFromString(@"Fabric");
+        if ([fabric respondsToSelector:@selector(configurationDictionaryForKitClass:)]) {
+
             NSDictionary *configDictionary = [fabric configurationDictionaryForKitClass:[Branch class]];
             ret = [configDictionary objectForKey:BNC_BRANCH_FABRIC_APP_KEY_KEY];
             
             if ([ret isKindOfClass:[NSString class]]) {
+
                 self.branchKey = ret;
-            }
-            else if ([ret isKindOfClass:[NSDictionary class]]) {
+
+            } else if ([ret isKindOfClass:[NSDictionary class]]) {
+
                 self.branchKey = isLive ? ret[@"live"] : ret[@"test"];
+                if (![self.branchKey isKindOfClass:NSString.class])
+                    self.branchKey = nil;
+
             }
         }
     }

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -177,7 +177,7 @@ static NSString * const BNC_BRANCH_FABRIC_APP_KEY_KEY = @"branch_key";
         else if ([ret isKindOfClass:[NSDictionary class]]) {
             self.branchKey = isLive ? ret[@"live"] : ret[@"test"];
         }
-        
+
     } else {
 
         Class fabric = NSClassFromString(@"Fabric");

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,12 @@
-Branch iOS SDK change log
+Branch iOS SDK Change Log
+
+- v0.12.15 (Pre-release)
+  * Check for older versions of the Fabric SDK instead of just crashing (AIS-102).
+    - Testing note:  This is a pretty contrived problem that isn't easily testable.
+      I stepped through the code with the debugger and it worked.
 
 - v0.12.14
-  *  This release fixes a compile error with Xcode 7.
+  * This release fixes a compile error with Xcode 7.
 
 - v0.12.13
   * AIS-106: Included user_agent in device POST parameters.
@@ -27,7 +32,7 @@ Branch iOS SDK change log
   * Fix for few swift compatibility issues
 
 - v0.12.10
-  * Fix for issue causing initsession hang on cold start from universal link
+  * Fix for issue causing initSession hang on cold start from universal link
   * Adding few crash protection
   * Removing BUO nullable fields
 
@@ -102,7 +107,7 @@ Branch iOS SDK change log
 - v0.11.17
   * Carthage support
   * account for different anchors on iPad for share sheet
-  * add canonincal ID and URL to spotlight index
+  * add canonical ID and URL to spotlight index
   * change matchDuration parameter sent to the backend
   * fix unit tests
   * URL encoding for iOS 6


### PR DESCRIPTION
- Check for older versions of the Fabric SDK instead of just crashing (AIS-102).
  - Testing note:  This is a pretty contrived problem that isn't easily testable.
    I stepped through the code with the debugger and it worked.
