### PR TITLE
Properly check class on +initialize calls

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -749,7 +749,9 @@ static NSString * const BNC_BRANCH_FABRIC_APP_KEY_KEY = @"branch_key";
 }
 
 + (void) initialize {
-    [self moveOldPrefsFile];
+    if (self == [BNCPreferenceHelper self]) {
+        [self moveOldPrefsFile];
+    }
 }
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
+++ b/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
@@ -321,7 +321,9 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
 }
 
 + (void) initialize {
-    [self moveOldQueueFile];
+    if (self == [BNCServerRequestQueue self]) {
+        [self moveOldQueueFile];
+    }
 }
 
 #pragma mark - Singleton method


### PR DESCRIPTION
Follow [Apple's documentation](https://developer.apple.com/reference/objectivec/nsobject/1418639-initialize) and check to make sure the class is the expected class in the `+ (void)initialize` methods. Apple's code listing 1:

``` Objective-c
+ (void)initialize {
  if (self == [ClassName self]) {
    // ... do the initialization ...
  }
}
```
