### PR TITLE
Clean up file presence warnings

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -660,9 +660,7 @@ static NSString * const BNC_BRANCH_FABRIC_APP_KEY_KEY = @"branch_key";
             NSError *error = nil;
             NSData *data = [NSData dataWithContentsOfURL:self.class.URLForPrefsFile
                     options:0 error:&error];
-            if (error || !data)
-                NSLog(@"Error opening prefs file: %@.", error);
-            else
+            if (!error && data)
                 persistenceDict = [NSKeyedUnarchiver unarchiveObjectWithData:data];
         }
         @catch (NSException *exception) {

--- a/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
+++ b/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
@@ -237,10 +237,7 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
     @try {
         NSError *error = nil;
         NSData *data = [NSData dataWithContentsOfURL:self.class.URLForQueueFile options:0 error:&error];
-        if (error || !data)
-            [[BNCPreferenceHelper preferenceHelper] logWarning:
-                [NSString stringWithFormat:@"Error loading network queue: %@.", error]];
-        else
+        if (!error && data)
             encodedRequests = [NSKeyedUnarchiver unarchiveObjectWithData:data];
     }
     @catch (NSException *exception) {


### PR DESCRIPTION
In this new file design, we were spitting out a giant error message for preferences and the queue when the first time the SDK was installed. We should not be throwing errors or warnings unless there's a problem. @ahmednawar 


