### PR TITLE
* iAd data is now sent on installs as well as opens & crash bug.

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCXcode7Support.h
+++ b/Branch-SDK/Branch-SDK/BNCXcode7Support.h
@@ -8,7 +8,7 @@
 
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 100000
-#warning Compiling with Xcode 7 support
+#warning Warning: Compiling with Xcode 7 support
 
 
 #import <Foundation/Foundation.h>

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -501,7 +501,7 @@ NSString * const BNCShareCompletedEvent = @"Share Completed";
         SEL sharedClient = NSSelectorFromString(@"sharedClient");
         SEL requestAttribution = NSSelectorFromString(@"requestAttributionDetailsWithBlock:");
 
-        if (ADClientClass &&
+        if (ADClientClass && [ADClientClass instancesRespondToSelector:requestAttribution] &&
             [ADClientClass methodForSelector:sharedClient]) {
             id sharedClientInstance = ((id (*)(id, SEL))[ADClientClass methodForSelector:sharedClient])(ADClientClass, sharedClient);
             

--- a/Branch-SDK/Branch-SDK/Requests/BranchInstallRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchInstallRequest.m
@@ -11,6 +11,7 @@
 #import "BNCSystemObserver.h"
 #import "BranchConstants.h"
 #import "BNCStrongMatchHelper.h"
+#import "BNCEncodingUtils.h"
 
 
 @implementation BranchInstallRequest
@@ -35,6 +36,17 @@
     [self safeSetValue:preferenceHelper.universalLinkUrl forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:params];
 
     params[BRANCH_REQUEST_KEY_DEBUG] = @(preferenceHelper.isDebug);
+
+    if (preferenceHelper.appleSearchAdDetails) {
+        NSString *encodedSearchData = nil;
+        @try {
+            NSData *jsonData = [BNCEncodingUtils encodeDictionaryToJsonData:preferenceHelper.appleSearchAdDetails];
+            encodedSearchData = [BNCEncodingUtils base64EncodeData:jsonData];
+        } @catch (id e) { }
+        [self safeSetValue:encodedSearchData
+                    forKey:BRANCH_REQUEST_KEY_SEARCH_AD
+                    onDict:params];
+    }
 
     if ([[BNCStrongMatchHelper strongMatchHelper] shouldDelayInstallRequest]) {
         NSInteger delay = 750;

--- a/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
@@ -66,7 +66,7 @@
     [self safeSetValue:cdDict forKey:BRANCH_CONTENT_DISCOVER_KEY onDict:params];    
 
     if (preferenceHelper.appleSearchAdDetails) {
-        NSString *encodedSearchData;
+        NSString *encodedSearchData = nil;
         @try {
             NSData *jsonData = [BNCEncodingUtils encodeDictionaryToJsonData:preferenceHelper.appleSearchAdDetails];
             encodedSearchData = [BNCEncodingUtils base64EncodeData:jsonData];

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -28,9 +28,9 @@
     [branch setDebug];
     
     // For Apple Search Ads
-    // [branch delayInitToCheckForSearchAds];
-    // [branch setAppleSearchAdsDebugMode];
-    
+    [branch delayInitToCheckForSearchAds];
+//  [branch setAppleSearchAdsDebugMode];
+
     [branch setWhiteListedSchemes:@[@"branchtest"]];
 
 
@@ -46,7 +46,12 @@
     // Required. Initialize session. automaticallyDisplayDeepLinkController is optional (default is NO).
     [branch initSessionWithLaunchOptions:launchOptions automaticallyDisplayDeepLinkController:YES deepLinkHandler:^(NSDictionary *params, NSError *error) {
         if (!error) {
+
             NSLog(@"initSession succeeded with params: %@", params);
+            NSDictionary *searchAds = [BNCPreferenceHelper preferenceHelper].appleSearchAdDetails;
+            NSLog(@"Search Ads:\n%@.", searchAds);    //  Apple Search ad demo.
+            NSLog(@"");
+
             // Deeplinking logic for use when automaticallyDisplayDeepLinkController = NO
             /*
              NSString *deeplinkText = [params objectForKey:@"deeplink_text"];

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -28,8 +28,8 @@
     [branch setDebug];
     
     // For Apple Search Ads
-    [branch delayInitToCheckForSearchAds];
-//  [branch setAppleSearchAdsDebugMode];
+    // [branch delayInitToCheckForSearchAds];
+    // [branch setAppleSearchAdsDebugMode];
 
     [branch setWhiteListedSchemes:@[@"branchtest"]];
 
@@ -48,10 +48,7 @@
         if (!error) {
 
             NSLog(@"initSession succeeded with params: %@", params);
-            NSDictionary *searchAds = [BNCPreferenceHelper preferenceHelper].appleSearchAdDetails;
-            NSLog(@"Search Ads:\n%@.", searchAds);    //  Apple Search ad demo.
-            NSLog(@"");
-
+           
             // Deeplinking logic for use when automaticallyDisplayDeepLinkController = NO
             /*
              NSString *deeplinkText = [params objectForKey:@"deeplink_text"];


### PR DESCRIPTION
* iAd data is now sent on installs as well as opens.
* Fixed iOS 8 crash bug when 'requestAttributionDetailsWithBlock:' is not present.
