### PR TITLE
INTENG-3110 Revert lifecycle handling change in 0.12.18

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -73,6 +73,7 @@ NSString * const BNCShareCompletedEvent = @"Share Completed";
 
 @property (strong, nonatomic) BNCServerInterface *bServerInterface;
 @property (strong, nonatomic) BNCServerRequestQueue *requestQueue;
+@property (strong, nonatomic) NSTimer *sessionTimer;
 @property (strong, nonatomic) dispatch_semaphore_t processing_sema;
 @property (copy,   nonatomic) callbackWithParams sessionInitWithParamsCallback;
 @property (copy,   nonatomic) callbackWithBranchUniversalObject sessionInitWithBranchUniversalObjectCallback;
@@ -93,7 +94,6 @@ NSString * const BNCShareCompletedEvent = @"Share Completed";
 @property (assign, nonatomic) BOOL delayForAppleAds;
 @property (assign, nonatomic) BOOL searchAdsDebugMode;
 @property (strong, nonatomic) NSMutableArray *whiteListedSchemeList;
-@property (assign, nonatomic) BOOL appIsInBackground;
 @end
 
 @implementation Branch
@@ -1164,15 +1164,15 @@ NSString * const BNCShareCompletedEvent = @"Share Completed";
 #pragma mark - Application State Change methods
 
 - (void)applicationDidBecomeActive {
-    self.appIsInBackground = NO;
+    [self clearTimer];
     if (!self.isInitialized && !self.preferenceHelper.shouldWaitForInit && ![self.requestQueue containsInstallOrOpen]) {
         [self initUserSessionAndCallCallback:YES];
     }
 }
 
 - (void)applicationWillResignActive {
-    self.appIsInBackground = YES;
-    [self callClose];
+    [self clearTimer];
+    self.sessionTimer = [NSTimer scheduledTimerWithTimeInterval:0.5 target:self selector:@selector(callClose) userInfo:nil repeats:NO];
     [self.requestQueue persistImmediately];
 }
 
@@ -1194,6 +1194,9 @@ NSString * const BNCShareCompletedEvent = @"Share Completed";
     }
 }
 
+- (void)clearTimer {
+    [self.sessionTimer invalidate];
+}
 
 #pragma mark - Queue management
 
@@ -1263,6 +1266,10 @@ NSString * const BNCShareCompletedEvent = @"Share Completed";
                 NSLog(@"[Branch Error] Missing session items!");
                 [req processResponse:nil error:[NSError errorWithDomain:BNCErrorDomain code:BNCInitError userInfo:@{ NSLocalizedDescriptionKey: @"Branch User Session has not been initialized" }]];
                 return;
+            }
+            
+            if (![req isKindOfClass:[BranchCloseRequest class]]) {
+                [self clearTimer];
             }
                         
             [req makeRequest:self.bServerInterface key:self.branchKey callback:callback];
@@ -1339,8 +1346,7 @@ NSString * const BNCShareCompletedEvent = @"Share Completed";
 }
 
 - (void)handleInitSuccess {
-    if (!self.appIsInBackground)
-        self.isInitialized = YES;
+    self.isInitialized = YES;
     
     NSDictionary *latestReferringParams = [self getLatestReferringParams];
     if (self.shouldCallSessionInitCallback) {


### PR DESCRIPTION
@ahmednawar 

An explanation of the new logic Ed introduced in 0.12.18: Only set initSuccess when the app is in the foreground

Whereas the old logic set initSuccess any time init successfully completed.

The new logic fails on link click, where continueUserActivity will complete initialization before the app can enter the foreground, causing Branch to re-initialize unnecessarily, and clearing the existing referral data. This PR reverts the above logic back to the old mechanism.