### PR TITLE
Fixed a crash when the root view controller is UINavigationController…

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.m
@@ -282,11 +282,13 @@
     self.matchView.alpha = 1.0;
     [self.matchView addSubview:self.matchViewController.view];
 
-    [self.primaryWindow.rootViewController addChildViewController:self.matchViewController];
-    UIView *parentView = self.primaryWindow.rootViewController.view ?: self.primaryWindow;
+    UIViewController *rootViewController = [self topViewController:self.primaryWindow.rootViewController];
+
+    [rootViewController addChildViewController:self.matchViewController];
+    UIView *parentView = rootViewController.view ?: self.primaryWindow;
     [parentView insertSubview:self.matchView atIndex:0];
 
-    [self.matchViewController didMoveToParentViewController:self.primaryWindow.rootViewController];
+    [self.matchViewController didMoveToParentViewController:rootViewController];
 
     return YES;
 }
@@ -308,6 +310,25 @@
     [BNCPreferenceHelper preferenceHelper].lastStrongMatchDate = [NSDate date];
     self.shouldDelayInstallRequest = NO;
     self.requestInProgress = NO;
+}
+
+/**
+  Find the top view controller that is not of type UINavigationController or UITabBarController
+ */
+- (UIViewController *)topViewController:(UIViewController *)baseViewController {
+    if ([baseViewController isKindOfClass:[UINavigationController class]]) {
+        return [self topViewController: ((UINavigationController *)baseViewController).visibleViewController];
+    }
+
+    if ([baseViewController isKindOfClass:[UITabBarController class]]) {
+        return [self topViewController: ((UITabBarController *)baseViewController).selectedViewController];
+    }
+
+    if ([baseViewController presentedViewController] != nil) {
+        return [self topViewController: [baseViewController presentedViewController]];
+    }
+
+    return baseViewController;
 }
 
 - (void)safariViewController:(SFSafariViewController *)controller


### PR DESCRIPTION
Here is what we observed:
- Upon first launch of the app after install, if a user taps on our sign up button within 3 seconds, this causes a set of events that quickly lead to a crash, with the underlying cause being the BNCMatchView.

Repro steps:
-Fresh install the Clarity Money App
- Launch the app
- Tap on Sign up within 3 seconds
- No sign up screen gets displayed
- A back button appears at the top
- Tapping the back button pops off the welcome screen and user is left with a 100% black screen
- Tapping on the Sign Up button again still doesn't display anything differently
- After tapping on Sign up a second time, if press back again, app crashes.

Detailed explanation of problem:
- It appears that Branch inserts a view controller instance into the view hierarchy (via BNCMatchView)
- BNCMatchViewController exists in the navigation stack, but as a child view controller of the navigation controller, not a child VC of a VC pushed on the navigation controller stack
- BNCMatchView is inserted in the view hierarchy outside of the navigation stack
- If a user taps to push a new VC on the nav stack before BNCMatchView removes itself, the navigation controller tries to push the sign up view controller
- While that sign up VC is trying to animated on the screen, BNCMatchView and BNCMatchViewController removes itself
- In removing itself, it breaks the navigation controller animation and/or the view hierarchy in that the pushed sign up VC never gets added or gets quickly removed from the view hierarchy. 
- The pushed sign up VC does still exist in memory, but not never displays in the view hierarchy

Solution:
- Inspect window's root view controller for navigation controller, tab bar, or presented view controller and fetch that class's currently presented VC and then let BNCView and BNCMatchViewController attach itself there.

Welcome Screen
<img width="300" alt="welcome" src="https://cloud.githubusercontent.com/assets/1009324/21689674/17e8c0da-d33f-11e6-9735-df68d7759065.png">


If the user waits for more than 3 seconds -OR- launches again after a crash, this view is properly pushed on the nav stack
<img width="300" alt="whatshouldhappen" src="https://cloud.githubusercontent.com/assets/1009324/21689677/17ec1866-d33f-11e6-986e-75d2029dca2c.png">


Welcome screen when tap on sign up within 3 seconds.  Notice no pushed sign up screen and notice the back button at top
<img width="300" alt="welcomeaftertapsignuptoosoon" src="https://cloud.githubusercontent.com/assets/1009324/21689676/17eb3b4e-d33f-11e6-96c8-2791a865a347.png">


Flow where user can get black screen:
<img width="300" alt="blackscreen" src="https://cloud.githubusercontent.com/assets/1009324/21689672/17e5fee0-d33f-11e6-8142-977e75d2f3f6.png">

View hierarchy capture on cold launch within 3 seconds
<img width="300" alt="coldlaunch_" src="https://cloud.githubusercontent.com/assets/1009324/21689675/17e9b13e-d33f-11e6-9593-9f6be0e282e8.png">



View hierarchy on second launch or if wait more than 3 seconds:
<img width="300" alt="2ndlaunch_" src="https://cloud.githubusercontent.com/assets/1009324/21689673/17e786b6-d33f-11e6-96fc-88e1ef8a1e66.png">



