### PR TITLE
Don't register iad attribution if not actually installed from search ad

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -528,7 +528,7 @@ NSString * const BNCShareCompletedEvent = @"Share Completed";
             void (^__nullable completionBlock)(NSDictionary *attrDetails, NSError *error) = ^void(NSDictionary *__nullable attrDetails, NSError *__nullable error) {
                 self.preferenceHelper.shouldWaitForInit = NO;
                 
-                if (attrDetails && [attrDetails count]) {
+                if ([[attrDetails valueForKey:@"Version3.1"] valueForKey:@"iad-attribution"]) {
                     self.preferenceHelper.appleSearchAdDetails = attrDetails;
                 }
                 else if (self.searchAdsDebugMode) {


### PR DESCRIPTION
I believe that currently there is a bug with apple search ads integration. The SDK works correctly when the app is installed from a search ad, or when `requestAttributionDetailsWithBlock:` returns no dictionary. However, sometimes a dictionary is returned with the format:
```javascript
{
  "Version3.1": {
    "iad-attribution": "false"
  }
}
```
In this case, the SDK incorrectly reports that the install was from a search ad. This one line change should solve the problem.
