### PR TITLE
Make callback block properties atomic/copy.

### DIFF
--- a/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
@@ -12,7 +12,7 @@
 
 @interface BranchLoadRewardsRequest ()
 
-@property (strong, nonatomic) callbackWithStatus callback;
+@property (copy) callbackWithStatus callback;
 
 @end
 

--- a/Branch-SDK/Branch-SDK/Requests/BranchLogoutRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchLogoutRequest.m
@@ -12,7 +12,7 @@
 
 @interface BranchLogoutRequest ()
 
-@property (strong, nonatomic) callbackWithStatus callback;
+@property (copy) callbackWithStatus callback;
 
 @end
 

--- a/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.h
+++ b/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.h
@@ -11,7 +11,7 @@
 
 @interface BranchOpenRequest : BNCServerRequest
 
-@property (copy, nonatomic) callbackWithStatus callback;
+@property (copy) callbackWithStatus callback;
 
 - (id)initWithCallback:(callbackWithStatus)callback;
 - (id)initWithCallback:(callbackWithStatus)callback isInstall:(BOOL)isInstall;

--- a/Branch-SDK/Branch-SDK/Requests/BranchRedeemRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchRedeemRewardsRequest.m
@@ -14,7 +14,7 @@
 
 @property (assign, nonatomic) NSInteger amount;
 @property (strong, nonatomic) NSString *bucket;
-@property (strong, nonatomic) callbackWithStatus callback;
+@property (copy) callbackWithStatus callback;
 
 @end
 


### PR DESCRIPTION
* This patch will solve some race condition crashes  when the callback is called before it is completely copied.
