### PR TITLE
Safe Dictionary:  Github Issues #551 & #552

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.m
@@ -12,6 +12,7 @@
 #import "BNCError.h"
 #import "BranchConstants.h"
 #import "BNCDeviceInfo.h"
+#import "NSMutableDictionary+Branch.h"
 
 void (^NSURLSessionCompletionHandler) (NSData *data, NSURLResponse *response, NSError *error);
 void (^NSURLConnectionCompletionHandler) (NSURLResponse *response, NSData *responseData, NSError *error);
@@ -231,8 +232,9 @@ NSString *requestEndpoint;
 - (NSDictionary *)prepareParamDict:(NSDictionary *)params
 							   key:(NSString *)key
 					   retryNumber:(NSInteger)retryNumber requestType:(NSString *)reqType {
+
     NSMutableDictionary *fullParamDict = [[NSMutableDictionary alloc] init];
-    [fullParamDict addEntriesFromDictionary:params];
+    [fullParamDict bnc_safeAddEntriesFromDictionary:params];
     fullParamDict[@"sdk"] = [NSString stringWithFormat:@"ios%@", BNC_SDK_VERSION];
     
     // using rangeOfString instead of containsString to support devices running pre iOS 8
@@ -243,8 +245,8 @@ NSString *requestEndpoint;
     fullParamDict[@"branch_key"] = key;
 
     NSMutableDictionary *metadata = [[NSMutableDictionary alloc] init];
-    [metadata addEntriesFromDictionary:self.preferenceHelper.requestMetadataDictionary];
-    [metadata addEntriesFromDictionary:fullParamDict[BRANCH_REQUEST_KEY_STATE]];
+    [metadata bnc_safeAddEntriesFromDictionary:self.preferenceHelper.requestMetadataDictionary];
+    [metadata bnc_safeAddEntriesFromDictionary:fullParamDict[BRANCH_REQUEST_KEY_STATE]];
     if (metadata.count) {
         fullParamDict[BRANCH_REQUEST_KEY_STATE] = metadata;
     }
@@ -287,7 +289,7 @@ NSString *requestEndpoint;
 - (void)updateDeviceInfoToMutableDictionary:(NSMutableDictionary *)dict {
     BNCDeviceInfo *deviceInfo  = [BNCDeviceInfo getInstance];
    
-    if (deviceInfo.hardwareId) {
+    if (deviceInfo.hardwareId && deviceInfo.hardwareIdType) {
         dict[BRANCH_REQUEST_KEY_HARDWARE_ID] = deviceInfo.hardwareId;
         dict[BRANCH_REQUEST_KEY_HARDWARE_ID_TYPE] = deviceInfo.hardwareIdType;
         dict[BRANCH_REQUEST_KEY_IS_HARDWARE_ID_REAL] = @(deviceInfo.isRealHardwareId);

--- a/Branch-SDK/Branch-SDK/NSMutableDictionary+Branch.h
+++ b/Branch-SDK/Branch-SDK/NSMutableDictionary+Branch.h
@@ -1,0 +1,18 @@
+//
+//  NSMutableDictionary+Branch.h
+//  Branch
+//
+//  Created by Edward Smith on 1/11/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+
+#import <Foundation/Foundation.h>
+
+
+@interface NSMutableDictionary (Branch)
+
+- (void) bnc_safeSetObject:(id)anObject forKey:(id<NSCopying>)aKey;
+- (void) bnc_safeAddEntriesFromDictionary:(NSDictionary<id<NSCopying>,id> *)otherDictionary;
+
+@end

--- a/Branch-SDK/Branch-SDK/NSMutableDictionary+Branch.m
+++ b/Branch-SDK/Branch-SDK/NSMutableDictionary+Branch.m
@@ -1,0 +1,27 @@
+//
+//  NSMutableDictionary+Branch.m
+//  Branch
+//
+//  Created by Edward Smith on 1/11/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+
+#import "NSMutableDictionary+Branch.h"
+
+
+@implementation NSMutableDictionary (Branch)
+
+- (void) bnc_safeSetObject:(id)anObject forKey:(id<NSCopying>)aKey {
+	if (anObject) {
+		[self setObject:anObject forKey:aKey];
+	}
+}
+
+- (void) bnc_safeAddEntriesFromDictionary:(NSDictionary<id<NSCopying>,id> *)otherDictionary {
+    if ([otherDictionary isKindOfClass:[NSDictionary class]]) {
+        [self addEntriesFromDictionary:otherDictionary];
+    }
+}
+
+@end

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		46DC40801B2B84CD00D2D203 /* BranchShortUrlRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46DC407F1B2B84CD00D2D203 /* BranchShortUrlRequestTests.m */; };
 		46FD92BA1AE7E8F80012E78F /* BNCSystemObserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46FD92B91AE7E8F80012E78F /* BNCSystemObserverTests.m */; };
 		46FFCF171ACC321A00039CE0 /* BNCEncodingUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46FFCF161ACC321A00039CE0 /* BNCEncodingUtilsTests.m */; };
+		4D35141B1E3201D80085EBA1 /* NSMutableDictionary+Branch.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D3514191E3201D80085EBA1 /* NSMutableDictionary+Branch.h */; };
+		4D35141C1E3201D80085EBA1 /* NSMutableDictionary+Branch.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D35141A1E3201D80085EBA1 /* NSMutableDictionary+Branch.m */; };
 		4D3FA94B1DFF31EB00E2B6A9 /* BNCConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D3FA94A1DFF31EB00E2B6A9 /* BNCConfig.m */; };
 		4D8999EC1DC108FF00F7EE0A /* BNCXcode7Support.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D8999EA1DC108FF00F7EE0A /* BNCXcode7Support.h */; };
 		4D8999ED1DC108FF00F7EE0A /* BNCXcode7Support.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D8999EB1DC108FF00F7EE0A /* BNCXcode7Support.m */; };
@@ -209,6 +211,8 @@
 		46DC407F1B2B84CD00D2D203 /* BranchShortUrlRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchShortUrlRequestTests.m; sourceTree = "<group>"; };
 		46FD92B91AE7E8F80012E78F /* BNCSystemObserverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCSystemObserverTests.m; sourceTree = "<group>"; };
 		46FFCF161ACC321A00039CE0 /* BNCEncodingUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCEncodingUtilsTests.m; sourceTree = "<group>"; };
+		4D3514191E3201D80085EBA1 /* NSMutableDictionary+Branch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableDictionary+Branch.h"; sourceTree = "<group>"; };
+		4D35141A1E3201D80085EBA1 /* NSMutableDictionary+Branch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableDictionary+Branch.m"; sourceTree = "<group>"; };
 		4D3FA94A1DFF31EB00E2B6A9 /* BNCConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCConfig.m; sourceTree = "<group>"; };
 		4D8999EA1DC108FF00F7EE0A /* BNCXcode7Support.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCXcode7Support.h; sourceTree = "<group>"; };
 		4D8999EB1DC108FF00F7EE0A /* BNCXcode7Support.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCXcode7Support.m; sourceTree = "<group>"; };
@@ -529,6 +533,8 @@
 				7D4DAC231C8FA908008E37DB /* BranchView.m */,
 				7D4DAC241C8FA908008E37DB /* BranchViewHandler.h */,
 				7D4DAC221C8FA908008E37DB /* BranchViewHandler.m */,
+				4D3514191E3201D80085EBA1 /* NSMutableDictionary+Branch.h */,
+				4D35141A1E3201D80085EBA1 /* NSMutableDictionary+Branch.m */,
 			);
 			name = "Branch-SDK";
 			path = "../Branch-SDK/Branch-SDK";
@@ -618,6 +624,7 @@
 				466D5A111B5991E3009DB845 /* BNCContentDiscoveryManager.h in Headers */,
 				466B58741B17780A00A69EDE /* BNCPreferenceHelper.h in Headers */,
 				4D8EE7A51E1F0A5D00B1F450 /* BNCCommerceEvent.h in Headers */,
+				4D35141B1E3201D80085EBA1 /* NSMutableDictionary+Branch.h in Headers */,
 				466B58791B17780A00A69EDE /* BNCConfig.h in Headers */,
 				7D4DAC211C8FA8C0008E37DB /* BranchView.h in Headers */,
 				7D4DAC271C8FA908008E37DB /* BranchViewHandler.h in Headers */,
@@ -854,6 +861,7 @@
 				4665AF261B28B9BB00184037 /* BranchConstants.m in Sources */,
 				466B58641B17779C00A69EDE /* BNCError.m in Sources */,
 				463F0A421B20A663004235D2 /* BranchInstallRequest.m in Sources */,
+				4D35141C1E3201D80085EBA1 /* NSMutableDictionary+Branch.m in Sources */,
 				7D0C97191D8753C9004E14B1 /* BranchContentDiscoverer.m in Sources */,
 				466B58661B17779C00A69EDE /* BNCServerResponse.m in Sources */,
 				466B58681B17779C00A69EDE /* BNCLinkData.m in Sources */,


### PR DESCRIPTION
This fixes Github issues #551 & #552.

I added a category to NSMutableDictionary that checks if an object is nil before trying to add it to a dictionary, preventing a potential crash.
