### PR TITLE
Framework improvements

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCCommerceEvent.h
+++ b/Branch-SDK/Branch-SDK/BNCCommerceEvent.h
@@ -7,7 +7,8 @@
 //
 
 
-#import <Foundation/Foundation.h>
+@import Foundation;
+
 #import "BNCServerRequest.h"
 
 

--- a/Branch-SDK/Branch-SDK/BNCConfig.h
+++ b/Branch-SDK/Branch-SDK/BNCConfig.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 extern NSString * const BNC_SDK_VERSION;
 extern NSString * const BNC_API_BASE_URL;

--- a/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.m
+++ b/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.m
@@ -13,7 +13,7 @@
 #import "BranchConstants.h"
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
-#import <MobileCoreServices/MobileCoreServices.h>
+@import MobileCoreServices;
 #endif
 
 #ifndef kUTTypeGeneric

--- a/Branch-SDK/Branch-SDK/BNCDeviceInfo.h
+++ b/Branch-SDK/Branch-SDK/BNCDeviceInfo.h
@@ -5,7 +5,8 @@
 //  Created by Sojan P.R. on 3/22/16.
 //  Copyright © 2016 Branch Metrics. All rights reserved.
 //
-#import <Foundation/Foundation.h>
+@import Foundation;
+
 #ifndef BNCDeviceInfo_h
 #define BNCDeviceInfo_h
 

--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.h
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface BNCEncodingUtils : NSObject
 

--- a/Branch-SDK/Branch-SDK/BNCError.h
+++ b/Branch-SDK/Branch-SDK/BNCError.h
@@ -7,7 +7,7 @@
 //
 
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 
 FOUNDATION_EXPORT NSString *_Nonnull const BNCErrorDomain;

--- a/Branch-SDK/Branch-SDK/BNCFabricAnswers.h
+++ b/Branch-SDK/Branch-SDK/BNCFabricAnswers.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface BNCFabricAnswers : NSObject
 

--- a/Branch-SDK/Branch-SDK/BNCLinkCache.h
+++ b/Branch-SDK/Branch-SDK/BNCLinkCache.h
@@ -6,7 +6,8 @@
 //  Copyright (c) 2015 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
+
 #import "BNCLinkData.h"
 
 @interface BNCLinkCache : NSObject

--- a/Branch-SDK/Branch-SDK/BNCLinkData.h
+++ b/Branch-SDK/Branch-SDK/BNCLinkData.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 typedef NS_ENUM(NSUInteger, BranchLinkType) {
     BranchLinkTypeUnlimitedUse = 0,

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 #define FILE_NAME   [[NSString stringWithUTF8String:__FILE__] lastPathComponent]
 #define LINE_NUM    __LINE__

--- a/Branch-SDK/Branch-SDK/BNCServerInterface.h
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.h
@@ -6,7 +6,8 @@
 //  Copyright (c) 2014 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
+
 #import "BNCServerResponse.h"
 #import "BNCPreferenceHelper.h"
 

--- a/Branch-SDK/Branch-SDK/BNCServerResponse.h
+++ b/Branch-SDK/Branch-SDK/BNCServerResponse.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface BNCServerResponse : NSObject
 

--- a/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.h
@@ -7,8 +7,8 @@
 //
 
 
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+@import Foundation;
+@import UIKit;
 
 
 @interface BNCStrongMatchHelper : NSObject

--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.h
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface BNCSystemObserver : NSObject
 

--- a/Branch-SDK/Branch-SDK/BNCXcode7Support.h
+++ b/Branch-SDK/Branch-SDK/BNCXcode7Support.h
@@ -11,7 +11,7 @@
 #warning Warning: Compiling with Xcode 7 support
 
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 
 @interface NSLocale (BranchXcode7Support)

--- a/Branch-SDK/Branch-SDK/Branch-SDK-Prefix.pch
+++ b/Branch-SDK/Branch-SDK/Branch-SDK-Prefix.pch
@@ -5,5 +5,5 @@
 //
 
 #ifdef __OBJC__
-    #import <Foundation/Foundation.h>
+    @import Foundation;
 #endif

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -5,8 +5,9 @@
 //  Created by Alex Austin on 6/5/14.
 //  Copyright (c) 2014 Branch Metrics. All rights reserved.
 //
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+@import Foundation;
+@import UIKit;
+
 #import "BNCConfig.h"
 #import "BranchView.h"
 #import "BNCCallbacks.h"

--- a/Branch-SDK/Branch-SDK/BranchActivityItemProvider.h
+++ b/Branch-SDK/Branch-SDK/BranchActivityItemProvider.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Branch Metrics. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 /**
  The `BranchActivityItemProviderDelegate` allows you  to customize the link parameters based on the channel chosen by the user.

--- a/Branch-SDK/Branch-SDK/BranchCSSearchableItemAttributeSet.h
+++ b/Branch-SDK/Branch-SDK/BranchCSSearchableItemAttributeSet.h
@@ -8,7 +8,8 @@
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
 
-#import <CoreSpotlight/CoreSpotlight.h>
+@import CoreSpotlight;
+
 #import "Branch.h"
 
 @interface BranchCSSearchableItemAttributeSet : CSSearchableItemAttributeSet

--- a/Branch-SDK/Branch-SDK/BranchCSSearchableItemAttributeSet.m
+++ b/Branch-SDK/Branch-SDK/BranchCSSearchableItemAttributeSet.m
@@ -8,11 +8,12 @@
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
 
+@import MobileCoreServices;
+
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BNCSystemObserver.h"
 #import "BNCError.h"
 #import "BranchConstants.h"
-#import <MobileCoreServices/MobileCoreServices.h>
 
 #ifndef kUTTypeGeneric
 #define kUTTypeGeneric @"public.content"

--- a/Branch-SDK/Branch-SDK/BranchConstants.h
+++ b/Branch-SDK/Branch-SDK/BranchConstants.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 extern NSString * const BRANCH_REQUEST_KEY_BRANCH_IDENTITY;
 extern NSString * const BRANCH_REQUEST_KEY_DEVELOPER_IDENTITY;

--- a/Branch-SDK/Branch-SDK/BranchContentDiscoverer.h
+++ b/Branch-SDK/Branch-SDK/BranchContentDiscoverer.h
@@ -7,7 +7,8 @@
 //
 
 
-#import <UIKit/UIKit.h>
+@import UIKit;
+
 #import "BranchContentDiscoveryManifest.h"
 
 

--- a/Branch-SDK/Branch-SDK/BranchContentDiscoverer.m
+++ b/Branch-SDK/Branch-SDK/BranchContentDiscoverer.m
@@ -7,13 +7,14 @@
 //
 
 
-#import <Foundation/Foundation.h>
+@import Foundation;
+@import UIKit;
+
 #import "BranchContentDiscoverer.h"
 #import "BranchContentDiscoveryManifest.h"
 #import "BranchContentPathProperties.h"
 #import "BNCPreferenceHelper.h"
 #import "BranchConstants.h"
-#import <UIKit/UIKit.h>
 #import <CommonCrypto/CommonDigest.h>
 #import "BNCEncodingUtils.h"
 

--- a/Branch-SDK/Branch-SDK/BranchContentDiscoveryManifest.h
+++ b/Branch-SDK/Branch-SDK/BranchContentDiscoveryManifest.h
@@ -5,8 +5,12 @@
 //  Created by Sojan P.R. on 8/18/16.
 //  Copyright © 2016 Branch Metrics. All rights reserved.
 //
+
+@import UIKit;
+
 #import "BranchContentPathProperties.h"
-#import <UIKit/UIKit.h>
+
+
 #ifndef ContentDiscoverManifest_h
 #define ContentDiscoverManifest_h
 

--- a/Branch-SDK/Branch-SDK/BranchContentDiscoveryManifest.m
+++ b/Branch-SDK/Branch-SDK/BranchContentDiscoveryManifest.m
@@ -6,12 +6,11 @@
 //  Copyright © 2016 Branch Metrics. All rights reserved.
 //
 
+@import Foundation;
 
-#import <Foundation/Foundation.h>
 #import "BranchContentDiscoveryManifest.h"
 #import "BNCPreferenceHelper.h"
 #import "BranchContentPathProperties.h"
-#import <UIKit/UIKit.h>
 #import "BranchConstants.h"
 
 

--- a/Branch-SDK/Branch-SDK/BranchContentPathProperties.m
+++ b/Branch-SDK/Branch-SDK/BranchContentPathProperties.m
@@ -6,7 +6,8 @@
 //  Copyright © 2016 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
+
 #import "BranchContentPathProperties.h"
 #import "BranchConstants.h"
 

--- a/Branch-SDK/Branch-SDK/BranchLinkProperties.h
+++ b/Branch-SDK/Branch-SDK/BranchLinkProperties.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface BranchLinkProperties : NSObject
 

--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.h
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.h
@@ -6,7 +6,8 @@
 //  Copyright © 2015 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
+
 #import "Branch.h"
 
 @class BranchLinkProperties;

--- a/Branch-SDK/Branch-SDK/BranchView.h
+++ b/Branch-SDK/Branch-SDK/BranchView.h
@@ -6,8 +6,9 @@
 //  Copyright © 2016 Branch Metrics. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
+@import Foundation;
+@import UIKit;
+
 
 @interface BranchView : NSObject
 //-------- properties-------------------//

--- a/Branch-SDK/Branch-SDK/BranchView.m
+++ b/Branch-SDK/Branch-SDK/BranchView.m
@@ -6,7 +6,8 @@
 //  Copyright © 2016 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
+
 #import "BranchView.h"
 #import "BNCPreferenceHelper.h"
 

--- a/Branch-SDK/Branch-SDK/BranchViewHandler.m
+++ b/Branch-SDK/Branch-SDK/BranchViewHandler.m
@@ -6,8 +6,9 @@
 //  Copyright © 2016 Branch Metrics. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+@import Foundation;
+@import UIKit;
+
 #import "BranchViewHandler.h"
 #import "Branch.h"
 #import "BranchView.h"

--- a/Branch-SDK/Branch-SDK/NSMutableDictionary+Branch.h
+++ b/Branch-SDK/Branch-SDK/NSMutableDictionary+Branch.h
@@ -7,7 +7,7 @@
 //
 
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 
 void ForceNSMutableDictionaryToLoad();

--- a/carthage-files/BranchSDK.xcodeproj/project.pbxproj
+++ b/carthage-files/BranchSDK.xcodeproj/project.pbxproj
@@ -193,7 +193,6 @@
 		E2B9477A1D15E31700F2270D /* BNCCallbacks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCCallbacks.h; sourceTree = "<group>"; };
 		E2B9477C1D15E3C100F2270D /* BNCFabricAnswers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCFabricAnswers.h; sourceTree = "<group>"; };
 		E2B9477D1D15E3C100F2270D /* BNCFabricAnswers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCFabricAnswers.m; sourceTree = "<group>"; };
-		E2B947861D15E78700F2270D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -329,7 +328,6 @@
 			isa = PBXGroup;
 			children = (
 				E298D0571C73D1B800589D22 /* Info.plist */,
-				E2B947861D15E78700F2270D /* module.modulemap */,
 				E230A1141D03DB9E006181D8 /* Branch-SDK */,
 				E230A1671D03DB9E006181D8 /* Fabric */,
 				E298D0531C73D1B800589D22 /* Products */,
@@ -431,6 +429,7 @@
 				TargetAttributes = {
 					E298D0511C73D1B800589D22 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0820;
 					};
 				};
 			};
@@ -609,6 +608,7 @@
 		E298D05B1C73D1B800589D22 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -617,18 +617,20 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "$(SRCROOT)/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.branch.ios-carthage";
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME)";
 				PRODUCT_NAME = Branch;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		E298D05C1C73D1B800589D22 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -637,12 +639,12 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "$(SRCROOT)/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.branch.ios-carthage";
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME)";
 				PRODUCT_NAME = Branch;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/carthage-files/module.modulemap
+++ b/carthage-files/module.modulemap
@@ -1,9 +1,0 @@
-framework module Branch {
-    umbrella header "Branch.h"
-
-    export *
-    module * { export * }
-
-    link framework "CoreTelephony"
-    link framework "MobileCoreServices"
-}


### PR DESCRIPTION
- Removes the now unneeded module map. This means for swift projects an objective-c bridging header is no longer required.

- Switched all imports to the new module import style, `@import ModuleName` for improved efficiency.