### PR TITLE
Update BNCStrongMatchHelper to handle UISplitViewController

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.m
@@ -254,7 +254,7 @@
 }
 
 /**
-  Find the top view controller that is not of type UINavigationController or UITabBarController
+  Find the top view controller that is not of type UINavigationController, UITabBarController, UISplitViewController
  */
 - (UIViewController *)topViewController:(UIViewController *)baseViewController {
     if ([baseViewController isKindOfClass:[UINavigationController class]]) {
@@ -263,6 +263,10 @@
 
     if ([baseViewController isKindOfClass:[UITabBarController class]]) {
         return [self topViewController: ((UITabBarController *)baseViewController).selectedViewController];
+    }
+
+    if ([baseViewController isKindOfClass:[UISplitViewController class]]) {
+        return [self topViewController: ((UISplitViewController *)baseViewController).viewControllers.firstObject];
     }
 
     if ([baseViewController presentedViewController] != nil) {


### PR DESCRIPTION
Similar to how UINavigationController and UITabBarController is
currently being handled when adding BNCMatchView. If we don't handle
UISplitViewController this way, BNCMatchViewController will end up in
the split view's viewControllers property which is unexpected and may
lead to crashes later. Split view's viewControllers should only have 1
or 2 view controllers depending on its collapsed / expanded state.

The special handling of UINavigationController and UITabBarController
was added in https://github.com/BranchMetrics/ios-branch-deep-linking/pull/539

