### PR TITLE
handle DeepLink URL with new session - AIS-264

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -339,11 +339,19 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
 - (BOOL)handleDeepLink:(NSURL *)url;
 
 /**
+ Allow Branch to reset the current session and handle deep link, returning whether it was from a Branch link or not.
+ @param url The url that caused the app to be opened.
+ */
+
+-(BOOL)handleDeepLinkWithNewSession:(NSURL *)url;
+
+/**
  Allow Branch to handle restoration from an NSUserActivity, returning whether or not it was
  from a Branch link.
  
  @param userActivity The NSUserActivity that caused the app to be opened.
  */
+
 - (BOOL)continueUserActivity:(NSUserActivity *)userActivity;
 
 /**

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -427,6 +427,10 @@ void ForceCategoriesToLoad() {
     return [self handleDeepLink:url fromSelf:NO];
 }
 
+-(BOOL)handleDeepLinkWithNewSession:(NSURL *)url{
+    return [self handleDeepLink:url fromSelf:YES];
+}
+
 - (BOOL)handleDeepLink:(NSURL *)url fromSelf:(BOOL)isFromSelf {
     BOOL handled = NO;
     if (url && ![url isEqual:[NSNull null]]) {


### PR DESCRIPTION
Addition for Appboy support where they can use the `-(BOOL)handleDeepLinkWithNewSession:(NSURL *)url;` method.

