### PR TITLE
automatic display of deeplink controller removed from testbed apps - AIS-127

### DIFF
--- a/Branch-TestBed-Swift/TestBed-Swift.xcodeproj/project.pbxproj
+++ b/Branch-TestBed-Swift/TestBed-Swift.xcodeproj/project.pbxproj
@@ -400,10 +400,10 @@
 			isa = PBXGroup;
 			children = (
 				63AAF0C11CF758AF00CA98BD /* AppDelegate.swift */,
+				63AAF1001CF7F58900CA98BD /* ContentViewController.swift */,
 				63AAF0C81CF758AF00CA98BD /* Assets.xcassets */,
 				63AAF0F01CF7594400CA98BD /* Branch.m */,
 				6306D5BE1D6A33A7000306B3 /* BranchUniversalObjectPropertiesTableViewController.swift */,
-				63AAF1001CF7F58900CA98BD /* ContentViewController.swift */,
 				63AAF0FC1CF7F4AD00CA98BD /* CreditHistoryViewController.swift */,
 				6306FFF21D6BEFB20031D2E3 /* Custom Events */,
 				63865EB61D617BED006071CE /* DataStore.swift */,

--- a/Branch-TestBed-Swift/TestBed-Swift/AppDelegate.swift
+++ b/Branch-TestBed-Swift/TestBed-Swift/AppDelegate.swift
@@ -27,6 +27,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             DataStore.setActiveBranchKey(defaultBranchKey)
         }
         
+        
+        // Deeplinking logic for use when automaticallyDisplayDeepLinkController = true
+        /*
+                    let navigationController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as! UINavigationController
+                    branch.registerDeepLinkController(navigationController, forKey:"~referring_link")
+ 
+         */
+
+        
         if let branch = Branch.getInstance(branchKey) {
             
             if DataStore.getPendingSetDebugEnabled()! {
@@ -36,35 +45,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 DataStore.setActivePendingSetDebugEnabled(false)
             }
             
-            let navigationController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as! UINavigationController
-            branch.registerDeepLinkController(navigationController, forKey:"~referring_link")
-            
             // Required. Initialize session. automaticallyDisplayDeepLinkController is optional (default is false).
-            branch.initSession(launchOptions: launchOptions, automaticallyDisplayDeepLinkController: true, deepLinkHandler: { params, error in
+            branch.initSession(launchOptions: launchOptions, automaticallyDisplayDeepLinkController: false, deepLinkHandler: { params, error in
                 
                 if (error == nil) {
                     
                     // Deeplinking logic for use when automaticallyDisplayDeepLinkController = false
-                    /*
-                     if let clickedBranchLink = params[BRANCH_INIT_KEY_CLICKED_BRANCH_LINK] as! Bool? {
-                     
-                     if clickedBranchLink {
-                     
-                     let nc = self.window!.rootViewController as! UINavigationController
-                     let storyboard = UIStoryboard(name: "Main", bundle: nil)
-                     let contentViewController = storyboard.instantiateViewController(withIdentifier: "Content") as! ContentViewController
-                     nc.pushViewController(contentViewController, animated: true)
-                     
-                     let dict = params as Dictionary
-                     let referringLink = dict["~referring_link"]
-                     let content = String(format:"\nReferring link: \(referringLink)\n\nSession Details:\n\(dict.JSONDescription())")
-                     contentViewController.content = content
-                     
-                     }
-                     } else {
-                     print(String(format: "Branch TestBed: Finished init with params\n%@", params.description))
-                     }
-                     */
+                    if let clickedBranchLink = params?[BRANCH_INIT_KEY_CLICKED_BRANCH_LINK] as! Bool? {
+                        
+                        if clickedBranchLink {
+                            
+                            let nc = self.window!.rootViewController as! UINavigationController
+                            let storyboard = UIStoryboard(name: "Main", bundle: nil)
+                            let contentViewController = storyboard.instantiateViewController(withIdentifier: "Content") as! ContentViewController
+                            nc.pushViewController(contentViewController, animated: true)
+                            contentViewController.contentType = "Content"
+                         
+                            
+                        }
+                    } else {
+                        print(String(format: "Branch TestBed: Finished init with params\n%@", (params?.description)!))
+                    }
+ 
                     
                 } else {
                     print("Branch TestBed: Initialization failed: " + error!.localizedDescription)

--- a/Branch-TestBed-Swift/TestBed-Swift/AppDelegate.swift
+++ b/Branch-TestBed-Swift/TestBed-Swift/AppDelegate.swift
@@ -45,9 +45,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 DataStore.setActivePendingSetDebugEnabled(false)
             }
             
-            // Required. Initialize session. automaticallyDisplayDeepLinkController is optional (default is false).
-            branch.initSession(launchOptions: launchOptions, automaticallyDisplayDeepLinkController: false, deepLinkHandler: { params, error in
-                
+            
+            branch.initSession(launchOptions: launchOptions, andRegisterDeepLinkHandler: { (params, error) in
                 if (error == nil) {
                     
                     // Deeplinking logic for use when automaticallyDisplayDeepLinkController = false
@@ -60,20 +59,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             let contentViewController = storyboard.instantiateViewController(withIdentifier: "Content") as! ContentViewController
                             nc.pushViewController(contentViewController, animated: true)
                             contentViewController.contentType = "Content"
-                         
+                            
                             
                         }
                     } else {
                         print(String(format: "Branch TestBed: Finished init with params\n%@", (params?.description)!))
                     }
- 
+                    
                     
                 } else {
                     print("Branch TestBed: Initialization failed: " + error!.localizedDescription)
                 }
                 let notificationName = Notification.Name("BranchCallbackCompleted")
                 NotificationCenter.default.post(name: notificationName, object: nil)
+
             })
+            
         } else {
             print("Branch TestBed: Invalid Key\n")
             DataStore.setActiveBranchKey("")

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -43,40 +43,30 @@
      * [self onboardUserOnInstall];
      */
     
-    // Deeplinking logic for use when automaticallyDisplayDeepLinkController = true
-    /*
-            [[UIStoryboard storyboardWithName:@"Main" bundle:[NSBundle mainBundle]]
-                instantiateInitialViewController];
-    
-        [branch registerDeepLinkController:navigationController forKey:@"deeplink_text"];
-     */
-
-    // Required. Initialize session. automaticallyDisplayDeepLinkController is optional (default is NO).
-    [branch initSessionWithLaunchOptions:launchOptions
-        automaticallyDisplayDeepLinkController:NO
-        deepLinkHandler:^(NSDictionary *params, NSError *error) {
+    [branch initSessionWithLaunchOptions:launchOptions andRegisterDeepLinkHandler:^(NSDictionary * _Nullable params, NSError * _Nullable error) {
         if (!error) {
-
+            
             NSLog(@"initSession succeeded with params: %@", params);
-                       
-             NSString *deeplinkText = [params objectForKey:@"deeplink_text"];
-             if (params[BRANCH_INIT_KEY_CLICKED_BRANCH_LINK] && deeplinkText) {
-             
-             UINavigationController *navigationController = (UINavigationController *)self.window.rootViewController;
-             UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
-             LogOutputViewController *logOutputViewController = [storyboard instantiateViewControllerWithIdentifier:@"LogOutputViewController"];
-             
-             [navigationController pushViewController:logOutputViewController animated:YES];
-             NSString *logOutput = [NSString stringWithFormat:@"Successfully Deeplinked:\n\n%@\nSession Details:\n\n%@", deeplinkText, [[branch getLatestReferringParams] description]];
-             logOutputViewController.logOutput = logOutput;
-             
-             } else {
-             NSLog(@"Branch TestBed: Finished init with params\n%@", params.description);
-             }
+            
+            NSString *deeplinkText = [params objectForKey:@"deeplink_text"];
+            if (params[BRANCH_INIT_KEY_CLICKED_BRANCH_LINK] && deeplinkText) {
+                
+                UINavigationController *navigationController = (UINavigationController *)self.window.rootViewController;
+                UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+                LogOutputViewController *logOutputViewController = [storyboard instantiateViewControllerWithIdentifier:@"LogOutputViewController"];
+                
+                [navigationController pushViewController:logOutputViewController animated:YES];
+                NSString *logOutput = [NSString stringWithFormat:@"Successfully Deeplinked:\n\n%@\nSession Details:\n\n%@", deeplinkText, [[branch getLatestReferringParams] description]];
+                logOutputViewController.logOutput = logOutput;
+                
+            } else {
+                NSLog(@"Branch TestBed: Finished init with params\n%@", params.description);
+            }
             
         } else {
             NSLog(@"Branch TestBed: Initialization failed\n%@", error.localizedDescription);
         }
+
     }];
 
     return YES;

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -38,28 +38,27 @@
     
     [branch setWhiteListedSchemes:@[@"branchtest"]];
 
-    // Automatic Deeplinking on "deeplink_text"
-    NavigationController *navigationController =
-        [[UIStoryboard storyboardWithName:@"Main" bundle:[NSBundle mainBundle]]
-            instantiateInitialViewController];
-
-    [branch registerDeepLinkController:navigationController forKey:@"deeplink_text"];
-    
     /**
      * // Optional. Use if presenting SFSafariViewController as part of onboarding. Cannot use with setDebug.
      * [self onboardUserOnInstall];
      */
+    
+    // Deeplinking logic for use when automaticallyDisplayDeepLinkController = true
+    /*
+            [[UIStoryboard storyboardWithName:@"Main" bundle:[NSBundle mainBundle]]
+                instantiateInitialViewController];
+    
+        [branch registerDeepLinkController:navigationController forKey:@"deeplink_text"];
+     */
 
     // Required. Initialize session. automaticallyDisplayDeepLinkController is optional (default is NO).
     [branch initSessionWithLaunchOptions:launchOptions
-        automaticallyDisplayDeepLinkController:YES
+        automaticallyDisplayDeepLinkController:NO
         deepLinkHandler:^(NSDictionary *params, NSError *error) {
         if (!error) {
 
             NSLog(@"initSession succeeded with params: %@", params);
-           
-            // Deeplinking logic for use when automaticallyDisplayDeepLinkController = NO
-            /*
+                       
              NSString *deeplinkText = [params objectForKey:@"deeplink_text"];
              if (params[BRANCH_INIT_KEY_CLICKED_BRANCH_LINK] && deeplinkText) {
              
@@ -74,7 +73,7 @@
              } else {
              NSLog(@"Branch TestBed: Finished init with params\n%@", params.description);
              }
-             */
+            
         } else {
             NSLog(@"Branch TestBed: Initialization failed\n%@", error.localizedDescription);
         }


### PR DESCRIPTION
Automatic display of deeplink controller is removed and is handled manually in the block of initSession in Appdelegate of obj-c and swift.
