### PR TITLE
Deprecate warning added in the functions using share sheet in BranchUniversalObject.h

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.h
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.h
@@ -55,14 +55,14 @@ typedef NS_ENUM(NSInteger, ContentIndexMode) {
 
 - (nullable UIActivityItemProvider *)getBranchActivityItemWithLinkProperties:(nonnull BranchLinkProperties *)linkProperties;
 
-- (void)showShareSheetWithShareText:(nullable NSString *)shareText completion:(nullable shareCompletion)completion;
-- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties andShareText:(nullable NSString *)shareText fromViewController:(nullable UIViewController *)viewController completion:(nullable shareCompletion)completion;
+- (void)showShareSheetWithShareText:(nullable NSString *)shareText completion:(nullable shareCompletion)completion __attribute__((deprecated(("Use presentActivityViewControllerFromViewController in BranchShareLink"))));
+- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties andShareText:(nullable NSString *)shareText fromViewController:(nullable UIViewController *)viewController completion:(nullable shareCompletion)completion __attribute__((deprecated(("Use presentActivityViewControllerFromViewController in BranchShareLink"))));
 // Returns with activityError as well
-- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties andShareText:(nullable NSString *)shareText fromViewController:(nullable UIViewController *)viewController completionWithError:(nullable shareCompletionWithError)completion;
+- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties andShareText:(nullable NSString *)shareText fromViewController:(nullable UIViewController *)viewController completionWithError:(nullable shareCompletionWithError)completion __attribute__((deprecated(("Use presentActivityViewControllerFromViewController in BranchShareLink"))));
 //iPad
-- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties andShareText:(nullable NSString *)shareText fromViewController:(nullable UIViewController *)viewController anchor:(nullable UIBarButtonItem *)anchor completion:(nullable shareCompletion)completion;
+- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties andShareText:(nullable NSString *)shareText fromViewController:(nullable UIViewController *)viewController anchor:(nullable UIBarButtonItem *)anchor completion:(nullable shareCompletion)completion __attribute__((deprecated(("Use presentActivityViewControllerFromViewController in BranchShareLink"))));
 // Returns with activityError as well
-- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties andShareText:(nullable NSString *)shareText fromViewController:(nullable UIViewController *)viewController anchor:(nullable UIBarButtonItem *)anchor completionWithError:(nullable shareCompletionWithError)completion;
+- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties andShareText:(nullable NSString *)shareText fromViewController:(nullable UIViewController *)viewController anchor:(nullable UIBarButtonItem *)anchor completionWithError:(nullable shareCompletionWithError)completion __attribute__((deprecated(("Use presentActivityViewControllerFromViewController in BranchShareLink"))));
 
 - (void)listOnSpotlight;
 - (void)listOnSpotlightWithCallback:(nullable callbackWithUrl)callback;


### PR DESCRIPTION
Deprecate Warning added on functions using Share Sheet in BranchUniversalObject - "Use presentActivityViewControllerFromViewController in BranchShareLink". This will give an intuition to the developer about the use of BranchShareLink.
