### PR TITLE
Fix Apple Search Ad Attribution - AIS-267

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.h
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.h
@@ -32,5 +32,6 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
 + (void)setUpdateState;
 + (BOOL)isSimulator;
 + (BOOL)adTrackingSafe;
++ (NSDate*) appInstallDate;
 
 @end

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -581,6 +581,16 @@ void ForceCategoriesToLoad() {
     if (!self.delayForAppleAds)
         return NO;
 
+    NSNumber *hasAppleSearchAdAttribution = self.preferenceHelper.appleSearchAdDetails[@"iad-attribution"];
+    if ([hasAppleSearchAdAttribution boolValue])
+        return NO;
+
+    NSDate *installDatePlus30 =
+        [[BNCSystemObserver appInstallDate] dateByAddingTimeInterval:(30.0*24.0*60.0*60.0)];
+    if ([installDatePlus30 compare:[NSDate date]] < 0) {
+        return NO;
+    }
+
     Class ADClientClass = NSClassFromString(@"ADClient");
     SEL sharedClient = NSSelectorFromString(@"sharedClient");
     SEL requestAttribution = NSSelectorFromString(@"requestAttributionDetailsWithBlock:");
@@ -627,7 +637,9 @@ void ForceCategoriesToLoad() {
             
             self.preferenceHelper.appleSearchAdDetails = testInfo;
         }
-        
+
+
+
         // if there's another async attribution check in flight, don't continue with init
         if (self.asyncRequestCount > 0) { return; }
         

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -226,7 +226,10 @@ NSString *type = @"some type";
     linkProperties.campaign = @"sharing campaign";
     [linkProperties addControlParam:@"$desktop_url" withValue: desktop_url];
     [linkProperties addControlParam:@"$ios_url" withValue: ios_url];
-    
+
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
     [self.branchUniversalObject showShareSheetWithLinkProperties:linkProperties
         andShareText:shareText
         fromViewController:self.parentViewController
@@ -238,6 +241,8 @@ NSString *type = @"some type";
             }
         }
     ];
+
+    #pragma clang diagnostic pop
 }
 
 - (IBAction)shareLinkButtonTouchUpInside:(id)sender {


### PR DESCRIPTION
Stop sending the Apple search ad data after attribution has been found or 30 days.
