### PR TITLE
Make it easier to use the Branch test key - AIS-287

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -15,7 +15,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory();
 
 @interface BNCPreferenceHelper : NSObject
 
-@property (strong, nonatomic) NSString *branchKey;
 @property (strong, nonatomic) NSString *lastRunBranchKey;
 @property (strong, nonatomic) NSDate   *lastStrongMatchDate;
 @property (strong, nonatomic) NSString *appVersion;
@@ -49,8 +48,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory();
 - (NSString *)getAPIBaseURL;
 - (NSString *)getAPIURL:(NSString *)endpoint;
 - (NSString *)getEndpointFromURL:(NSString *)url;
-
-- (NSString *)getBranchKey:(BOOL)isLive;
 
 - (void)clearUserCreditsAndCounts;
 - (void)clearUserCredits;

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -45,9 +45,6 @@ NSString * const BRANCH_PREFS_KEY_BRANCH_VIEW_USAGE_CNT = @"bnc_branch_view_usag
 NSString * const BRANCH_PREFS_KEY_ANALYTICAL_DATA = @"bnc_branch_analytical_data";
 NSString * const BRANCH_PREFS_KEY_ANALYTICS_MANIFEST = @"bnc_branch_analytics_manifest";
 
-// The name of this key was specified in the account-creation API integration
-static NSString * const BNC_BRANCH_FABRIC_APP_KEY_KEY = @"branch_key";
-
 @interface BNCPreferenceHelper () {
     NSOperationQueue *_persistPrefsQueue;
     NSString         *_lastSystemBuildVersion;
@@ -65,7 +62,7 @@ static NSString * const BNC_BRANCH_FABRIC_APP_KEY_KEY = @"branch_key";
 
 @implementation BNCPreferenceHelper
 
-@synthesize branchKey = _branchKey,
+@synthesize
             lastRunBranchKey = _lastRunBranchKey,
             appVersion = _appVersion,
             deviceFingerprintID = _deviceFingerprintID,
@@ -199,52 +196,6 @@ static NSString * const BNC_BRANCH_FABRIC_APP_KEY_KEY = @"branch_key";
 }
 
 #pragma mark - Preference Storage
-
-- (NSString *)getBranchKey:(BOOL)isLive {
-    // Already loaded a key, and it's the same state (live/test)
-    if (_branchKey && isLive == self.isUsingLiveKey) {
-        return _branchKey;
-    }
-    
-    self.isUsingLiveKey = isLive;
-
-    id ret = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"branch_key"];
-    if (ret) {
-        if ([ret isKindOfClass:[NSString class]]) {
-            self.branchKey = ret;
-        }
-        else if ([ret isKindOfClass:[NSDictionary class]]) {
-            self.branchKey = isLive ? ret[@"live"] : ret[@"test"];
-        }
-
-    } else {
-
-        Class fabric = NSClassFromString(@"Fabric");
-        if ([fabric respondsToSelector:@selector(configurationDictionaryForKitClass:)]) {
-
-            NSDictionary *configDictionary = [fabric configurationDictionaryForKitClass:[Branch class]];
-            ret = [configDictionary objectForKey:BNC_BRANCH_FABRIC_APP_KEY_KEY];
-            
-            if ([ret isKindOfClass:[NSString class]]) {
-
-                self.branchKey = ret;
-
-            } else if ([ret isKindOfClass:[NSDictionary class]]) {
-
-                self.branchKey = isLive ? ret[@"live"] : ret[@"test"];
-                if (![self.branchKey isKindOfClass:NSString.class])
-                    self.branchKey = nil;
-
-            }
-        }
-    }
-    
-    return _branchKey;
-}
-
-- (void)setBranchKey:(NSString *)branchKey {
-    _branchKey = branchKey;
-}
 
 - (NSString *)lastRunBranchKey {
     if (!_lastRunBranchKey) {

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -135,6 +135,14 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
 ///--------------------------------
 
 /**
+ Gets the global, test Branch instance.
+
+ @warning This method is not meant to be used in production!
+*/
++ (Branch *) getTestInstance __attribute__((deprecated(("Use `Branch.useTestBranchKey = YES;` instead."))));
+
+
+/**
  Gets the global, live Branch instance.
  */
 + (Branch *)getInstance;

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -140,13 +140,6 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
 + (Branch *)getInstance;
 
 /**
- Gets the global, test Branch instance.
- 
- @warning This method is not meant to be used in production!
- */
-+ (Branch *)getTestInstance;
-
-/**
  Gets the global Branch instance, configures using the specified key
  
  @param branchKey The Branch key to be used by the Branch instance. This can be any live or test key.
@@ -154,6 +147,33 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  */
 + (Branch *)getInstance:(NSString *)branchKey;
 
+/// TODO: Document:
+/**
+    Sets Branch to use the test `key_test_...` Branch key found in the Info.plist.
+    This can only be set before `[Branch getInstance...]` is called.
+    
+ @param useTestKey If YES then Branch to use the Branch test found in your app's Info.plist.
+*/
++ (void) setUseTestBranchKey:(BOOL)useTestKey;
+
+/// @return Returns true if the Branch test key should be used.
++ (BOOL) useTestBranchKey;
+
+/**
+ Directly sets the Branch key to be used.  Branch usually reads the Branch key from your app's
+ Info.plist file which is recommended and more convenient.  But the Branch key can also be set 
+ with this method. See the documentation at
+   https://dev.branch.io/getting-started/sdk-integration-guide/guide/ios/#configure-xcode-project
+ for information about configuring your app with Branch keys.
+ 
+ You can only set the Branch key once per app run.
+
+ @param branchKey The Branch key to use.
+*/
++ (void) setBranchKey:(NSString*)branchKey;
+
+/// @return Returns the current Branch key.
++ (NSString*) branchKey;
 
 #pragma mark - BranchActivityItemProvider methods
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -98,7 +98,6 @@ void ForceCategoriesToLoad() {
 @property (strong, nonatomic) BNCLinkCache *linkCache;
 @property (strong, nonatomic) BNCPreferenceHelper *preferenceHelper;
 @property (strong, nonatomic) BNCContentDiscoveryManager *contentDiscoveryManager;
-@property (strong, nonatomic) NSString *branchKey;
 @property (strong, nonatomic) NSMutableDictionary *deepLinkControllers;
 @property (weak,   nonatomic) UIViewController *deepLinkPresentingController;
 @property (assign, nonatomic) BOOL useCookieBasedMatching;
@@ -128,45 +127,12 @@ void ForceCategoriesToLoad() {
 }
 
 + (Branch *)getInstance {
-    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-    
-    // If no Branch Key
-    NSString *branchKey = [preferenceHelper getBranchKey:YES];
-    NSString *keyToUse = branchKey;
-    if (!branchKey) {
-        BNCLogWarning(@"Please enter your branch_key in the plist!");
-        return nil;
-    }
-
-    return [Branch getInstanceInternal:keyToUse returnNilIfNoCurrentInstance:NO];
-}
-
-+ (Branch *)getTestInstance {
-    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-    
-    // If no Branch Key
-    NSString *branchKey = [preferenceHelper getBranchKey:NO];
-    NSString *keyToUse = branchKey;
-    if (!branchKey) {
-        BNCLogWarning(@"Please enter your branch_key in the plist!");
-        return nil;
-    }
-    
-    return [Branch getInstanceInternal:keyToUse returnNilIfNoCurrentInstance:NO];
+    return [Branch getInstanceInternal:self.class.branchKey returnNilIfNoCurrentInstance:NO];
 }
 
 + (Branch *)getInstance:(NSString *)branchKey {
-    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-    
-    if ([branchKey hasPrefix:@"key_"]) {
-        preferenceHelper.branchKey = branchKey;
-    }
-    else {
-        BNCLogError(@"Invalid Branch key format!");
-        return nil;
-    }
-    
-    return [Branch getInstanceInternal:branchKey returnNilIfNoCurrentInstance:NO];
+    self.branchKey = branchKey;
+    return [Branch getInstanceInternal:self.branchKey returnNilIfNoCurrentInstance:NO];
 }
 
 - (id)initWithInterface:(BNCServerInterface *)interface queue:(BNCServerRequestQueue *)queue cache:(BNCLinkCache *)cache preferenceHelper:(BNCPreferenceHelper *)preferenceHelper key:(NSString *)key {
@@ -179,7 +145,6 @@ void ForceCategoriesToLoad() {
         _requestQueue = queue;
         _linkCache = cache;
         _preferenceHelper = preferenceHelper;
-        _branchKey = key;
         
         _contentDiscoveryManager = [[BNCContentDiscoveryManager alloc] init];
         _isInitialized = NO;
@@ -235,6 +200,102 @@ void ForceCategoriesToLoad() {
 
 #pragma mark - Configuration methods
 
+static BOOL bnc_useTestBranchKey = NO;
+
++ (void) setUseTestBranchKey:(BOOL)useTestKey {
+    @synchronized (self) {
+        if (bnc_branchKey && !!useTestKey != !!bnc_useTestBranchKey) {
+            NSString*message=@"The Branch key is already set. The key can only be set only  once.";
+            BNCLogError(message);
+            [NSException raise:NSInternalInconsistencyException format:@"%@", message];
+            return;
+        }
+        bnc_useTestBranchKey = useTestKey;
+    }
+}
+
++ (BOOL) useTestBranchKey {
+    @synchronized (self) {
+        return bnc_useTestBranchKey;
+    }
+}
+
+static NSString *bnc_branchKey = nil;
+
++ (void) setBranchKey:(NSString*)branchKey {
+    @synchronized (self) {
+        if (bnc_branchKey) {
+            if (![bnc_branchKey isEqualToString:branchKey]) {
+                NSString*message=@"The Branch key is already set. The key can only be set only once.";
+                BNCLogError(@"%@", message);
+                [NSException raise:NSInternalInconsistencyException format:@"%@", message];
+            }
+            return;
+        }
+
+        if (![branchKey isKindOfClass:[NSString class]]) {
+            [NSException raise:NSInternalInconsistencyException
+                format:@"Invalid Branch key of type '%@'.", NSStringFromClass(branchKey.class)];
+            return;
+        }
+
+        if ([branchKey hasPrefix:@"key_test"]) {
+            bnc_useTestBranchKey = YES;
+            BNCLogWarning(
+                @"You are using your test app's Branch Key. "
+                 "Remember to change it to live Branch Key for deployment."
+            );
+        } else
+        if ([branchKey hasPrefix:@"key_live"]) {
+            bnc_useTestBranchKey = NO;
+        } else {
+            [NSException raise:NSInternalInconsistencyException
+                format:@"Invalid Branch key format '%@'.", branchKey];
+            return;
+        }
+
+        bnc_branchKey = branchKey;
+    }
+}
+
++ (NSString*) branchKey {
+    @synchronized (self) {
+        if (bnc_branchKey) return bnc_branchKey;
+
+        // The name of this key was specified in the Fabric account-creation API integration
+        NSString * const BNC_BRANCH_FABRIC_APP_KEY_KEY = @"branch_key";
+
+        NSDictionary *branchDictionary =
+            [[[NSBundle mainBundle] infoDictionary] objectForKey:BNC_BRANCH_FABRIC_APP_KEY_KEY];
+
+        if (!branchDictionary) {
+            Class fabric = NSClassFromString(@"Fabric");
+            if ([fabric respondsToSelector:@selector(configurationDictionaryForKitClass:)]) {
+                NSDictionary *configDictionary = [fabric configurationDictionaryForKitClass:[Branch class]];
+                branchDictionary = [configDictionary objectForKey:BNC_BRANCH_FABRIC_APP_KEY_KEY];
+            }
+        }
+
+        if (!branchDictionary) {
+            BNCLogError(@"Your Branch key is not set in your Info.plist file."
+                " See https://dev.branch.io/getting-started/sdk-integration-guide/guide/ios/#configure-xcode-project for configuration instructions.");
+            return nil;
+        }
+
+        NSString *branchKey = nil;
+        if ([branchDictionary isKindOfClass:[NSString class]]) {
+            branchKey = (NSString*) branchDictionary;
+        } else
+        if ([branchDictionary isKindOfClass:[NSDictionary class]]) {
+            branchKey =
+                (self.useTestBranchKey) ? branchDictionary[@"test"] : branchDictionary[@"live"];
+        }
+
+        self.branchKey = branchKey;
+        return bnc_branchKey;
+    }
+}
+
 - (void)setDebug {
     self.preferenceHelper.isDebug = YES;
     BNCLogSetDisplayLevel(BNCLogLevelDebug);
@@ -287,7 +348,7 @@ void ForceCategoriesToLoad() {
 }
 
 - (NSURL *)getUrlForOnboardingWithRedirectUrl:(NSString *)redirectUrl {
-    return [BNCStrongMatchHelper getUrlForCookieBasedMatchingWithBranchKey:self.branchKey redirectUrl:redirectUrl];
+    return [BNCStrongMatchHelper getUrlForCookieBasedMatchingWithBranchKey:self.class.branchKey redirectUrl:redirectUrl];
 }
 
 - (void)resumeInit {
@@ -1272,7 +1333,7 @@ void ForceCategoriesToLoad() {
         
         if (self.isInitialized) {
             BNCLogDebug(@"Created a custom URL synchronously.");
-            BNCServerResponse *serverResponse = [req makeRequest:self.bServerInterface key:self.branchKey];
+            BNCServerResponse *serverResponse = [req makeRequest:self.bServerInterface key:self.class.branchKey];
             shortURL = [req processResponse:serverResponse];
             
             // cache the link
@@ -1281,8 +1342,8 @@ void ForceCategoriesToLoad() {
             }
         } else {
             if (forceLinkCreation) {
-                if (self.branchKey) {
-                    return [BranchShortUrlSyncRequest createLinkFromBranchKey:self.branchKey
+                if (self.class.branchKey) {
+                    return [BranchShortUrlSyncRequest createLinkFromBranchKey:self.class.branchKey
                         tags:tags alias:alias type:type matchDuration:duration
                             channel:channel feature:feature stage:stage params:params];
                 }
@@ -1301,7 +1362,7 @@ void ForceCategoriesToLoad() {
                                andStage:(NSString *)stage
                                andAlias:(NSString *)alias {
 
-    NSString *baseLongUrl = [NSString stringWithFormat:@"%@/a/%@", BNC_LINK_URL, self.branchKey];
+    NSString *baseLongUrl = [NSString stringWithFormat:@"%@/a/%@", BNC_LINK_URL, self.class.branchKey];
     
     return [self longUrlWithBaseUrl:baseLongUrl params:params tags:tags feature:feature
         channel:nil stage:stage alias:alias duration:0 type:BranchLinkTypeUnlimitedUse];
@@ -1525,7 +1586,7 @@ void BNCPerformBlockOnMainThread(dispatch_block_t block) {
 
             dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
             dispatch_async(queue, ^ {
-                [req makeRequest:self.bServerInterface key:self.branchKey callback:
+                [req makeRequest:self.bServerInterface key:self.class.branchKey callback:
                     ^(BNCServerResponse* response, NSError* error) {
                         [self processRequest:req response:response error:error];
                 }];
@@ -1570,17 +1631,6 @@ void BNCPerformBlockOnMainThread(dispatch_block_t block) {
 }
 
 - (void)initializeSession {
-    if (!self.branchKey) {
-        BNCLogWarning(@"Please enter your branch_key in the plist!");
-        return;
-    }
-    else if ([self.branchKey rangeOfString:@"key_test_"].location != NSNotFound) {
-        BNCLogWarning(
-            @"You are using your test app's Branch Key. "
-             "Remember to change it to live Branch Key for deployment."
-        );
-    }
-
 	Class clazz = [BranchInstallRequest class];
 	if (self.preferenceHelper.identityID) {
 		clazz = [BranchOpenRequest class];
@@ -1597,7 +1647,7 @@ void BNCPerformBlockOnMainThread(dispatch_block_t block) {
     };
 
     if ([BNCSystemObserver getOSVersion].integerValue >= 9 && self.useCookieBasedMatching) {
-        [[BNCStrongMatchHelper strongMatchHelper] createStrongMatchWithBranchKey:self.branchKey];
+        [[BNCStrongMatchHelper strongMatchHelper] createStrongMatchWithBranchKey:self.class.branchKey];
     }
 
 	@synchronized (self) {

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -140,7 +140,11 @@ void ForceCategoriesToLoad() {
     return [Branch getInstanceInternal:self.branchKey returnNilIfNoCurrentInstance:NO];
 }
 
-- (id)initWithInterface:(BNCServerInterface *)interface queue:(BNCServerRequestQueue *)queue cache:(BNCLinkCache *)cache preferenceHelper:(BNCPreferenceHelper *)preferenceHelper key:(NSString *)key {
+- (id)initWithInterface:(BNCServerInterface *)interface
+                  queue:(BNCServerRequestQueue *)queue
+                  cache:(BNCLinkCache *)cache
+       preferenceHelper:(BNCPreferenceHelper *)preferenceHelper
+                    key:(NSString *)key {
     if (self = [super init]) {
 
         ForceCategoriesToLoad();
@@ -160,7 +164,7 @@ void ForceCategoriesToLoad() {
         _deepLinkControllers = [[NSMutableDictionary alloc] init];
         _whiteListedSchemeList = [[NSMutableArray alloc] init];
         _useCookieBasedMatching = YES;
-
+        self.class.branchKey = key;
         [BranchOpenRequest setWaitNeededForOpenResponseLock];
 
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];

--- a/Branch-TestBed/Branch-SDK-Tests/BranchSDKFunctionalityTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BranchSDKFunctionalityTests.m
@@ -44,7 +44,7 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
 
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-    preferenceHelper.branchKey = @"foo";
+    Branch.branchKey = @"key_live_foo";
     
     Branch *branch =
         [[Branch alloc]
@@ -52,7 +52,7 @@ NSInteger const  TEST_CREDITS = 30;
             queue:[[BNCServerRequestQueue alloc] init]
             cache:[[BNCLinkCache alloc] init]
             preferenceHelper:preferenceHelper
-            key:@"foo"];
+            key:@"key_live_foo"];
     
     BNCServerResponse *openInstallResponse = [[BNCServerResponse alloc] init];
     openInstallResponse.data = @{
@@ -558,10 +558,11 @@ NSInteger const  TEST_CREDITS = 30;
         url:openOrInstallUrlCheckBlock
         key:[OCMArg any]
         callback:openOrInstallCallbackCheckBlock];
-    
-    // Fake branch key
-    id preferenceHelperMock = OCMClassMock([BNCPreferenceHelper class]);
-    [[[preferenceHelperMock stub] andReturn:@"foo"] getBranchKey:YES];
+
+//TODO
+//    // Fake branch key
+//    id preferenceHelperMock = OCMClassMock([BNCPreferenceHelper class]);
+//    [[[preferenceHelperMock stub] andReturn:@"key_live_foo"] getBranchKey:YES];
 }
 
 @end

--- a/Branch-TestBed/Branch-SDK-Tests/BranchSDKLoadTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BranchSDKLoadTests.m
@@ -34,7 +34,7 @@
             queue:[[BNCServerRequestQueue alloc] init]
             cache:[[BNCLinkCache alloc] init]
             preferenceHelper:preferenceHelper
-            key:@"key_foo"];
+            key:@"key_live_foo"];
 
     BNCServerResponse *linkResponse = [[BNCServerResponse alloc] init];
     linkResponse.data = @{ @"url": @"https://bnc.lt/l/3PxZVFU-BK" };
@@ -89,7 +89,7 @@
             callback:openOrInstallCallbackCheckBlock];
 
     // Fake branch key
-    preferenceHelper.branchKey = @"foo";
+    Branch.branchKey = @"key_live_foo";
 
     __block int32_t completedCount = 0;
     for (int i = 0; i < 1000; i++) {

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -26,7 +26,7 @@
     Branch.useTestBranchKey = YES;  // Make sure to comment this line out for production apps!!!
 
     Branch *branch = [Branch getInstance];
-    
+
     // Comment / un-comment to toggle debugging:
     [branch setDebug];
 

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -20,10 +20,10 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    /**
-     * // Push notification support (Optional)
-     * [self registerForPushNotifications:application];
-     */
+
+    // Have Branch use the Branch test key that is in the app's Info.plist file.
+    // This makes Branch test against the test environment instead of the live environment.
+    Branch.useTestBranchKey = YES;  // Make sure to comment this line out for production apps!!!
 
     Branch *branch = [Branch getInstance];
     
@@ -68,6 +68,11 @@
         }
 
     }];
+
+    /**
+     * // Push notification support (Optional)
+     * [self registerForPushNotifications:application];
+     */
 
     return YES;
 }
@@ -162,7 +167,8 @@ continueUserActivity:(NSUserActivity *)userActivity
     }
 }
 
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+- (void)application:(UIApplication *)application
+didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
     NSLog(@"Registered for remote notifications with APN device token: %@", deviceToken);
 }
 
@@ -171,7 +177,8 @@ continueUserActivity:(NSUserActivity *)userActivity
     // process your non-Branch notification payload items here...
 }
 
--(void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+-(void)application:(UIApplication *)application
+didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
     NSLog(@"Error registering for remote notifications: %@", error);
 }
 


### PR DESCRIPTION
Right now, switching between the `key_test` and the `key_live` confusing.

If the user can set a boolean or explicitly set the key before initialization then switching between live/test is a simple one line code change for the partner.
Options
