### PR TITLE
Crashlytics report enhancement

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCCrashlyticsWrapper.h
+++ b/Branch-SDK/Branch-SDK/BNCCrashlyticsWrapper.h
@@ -21,14 +21,10 @@
 + (instancetype _Nonnull)wrapper;
 
 /**
- * Use this method to set key values in a Crashlytics report. Note that
- * nil is acceptable for the value. Presumably this removes any key
- * previously set.
- *
- * This method name is deliberately chosen to match the Crashlytics
- * name in order to eliminate some compilation issues involving
- * unknown selectors.
+ * Use these methods to set key values in a Crashlytics report.
  */
 - (void)setObjectValue:(id _Nullable)value forKey:(NSString * _Nonnull)key;
-
+- (void)setIntValue:(int)value forKey:(NSString * _Nonnull)key;
+- (void)setBoolValue:(BOOL)value forKey:(NSString * _Nonnull)key;
+- (void)setFloatValue:(float)value forKey:(NSString * _Nonnull)key;
 @end

--- a/Branch-SDK/Branch-SDK/BNCCrashlyticsWrapper.h
+++ b/Branch-SDK/Branch-SDK/BNCCrashlyticsWrapper.h
@@ -1,0 +1,34 @@
+//
+//  BNCCrashlyticsWrapper.h
+//  Branch.framework
+//
+//  Created by Jimmy Dee on 7/18/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ * Convenience class to dynamically wrap the Crashlytics SDK
+ * if present. If it is not present, everything here is a no-op.
+ */
+@interface BNCCrashlyticsWrapper : NSObject
+
+/// Reference to the Crashlytics.sharedInstance or nil.
+@property (nonatomic, nullable, readonly) id crashlytics;
+
+/// Convenience method to create new instances
++ (instancetype _Nonnull)wrapper;
+
+/**
+ * Use this method to set key values in a Crashlytics report. Note that
+ * nil is acceptable for the value. Presumably this removes any key
+ * previously set.
+ *
+ * This method name is deliberately chosen to match the Crashlytics
+ * name in order to eliminate some compilation issues involving
+ * unknown selectors.
+ */
+- (void)setObjectValue:(id _Nullable)value forKey:(NSString * _Nonnull)key;
+
+@end

--- a/Branch-SDK/Branch-SDK/BNCCrashlyticsWrapper.m
+++ b/Branch-SDK/Branch-SDK/BNCCrashlyticsWrapper.m
@@ -31,16 +31,14 @@
     if (self) {
         // Dynamically obtain Crashlytics.sharedInstance if the Crashlytics SDK is linked.
         Class Crashlytics = NSClassFromString(@"Crashlytics");
-        if (Crashlytics) {
-            if ([Crashlytics respondsToSelector:@selector(sharedInstance)]) {
-                id crashlyticsInstance = [Crashlytics sharedInstance];
-                if ([crashlyticsInstance isKindOfClass:Crashlytics] &&
-                    [crashlyticsInstance respondsToSelector:@selector(setObjectValue:forKey:)] &&
-                    [crashlyticsInstance respondsToSelector:@selector(setBoolValue:forKey:)] &&
-                    [crashlyticsInstance respondsToSelector:@selector(setFloatValue:forKey:)] &&
-                    [crashlyticsInstance respondsToSelector:@selector(setIntValue:forKey:)])
-                    _crashlytics = crashlyticsInstance;
-            }
+        if ([Crashlytics respondsToSelector:@selector(sharedInstance)]) {
+            id crashlyticsInstance = [Crashlytics sharedInstance];
+            if ([crashlyticsInstance isKindOfClass:Crashlytics] &&
+                [crashlyticsInstance respondsToSelector:@selector(setObjectValue:forKey:)] &&
+                [crashlyticsInstance respondsToSelector:@selector(setBoolValue:forKey:)] &&
+                [crashlyticsInstance respondsToSelector:@selector(setFloatValue:forKey:)] &&
+                [crashlyticsInstance respondsToSelector:@selector(setIntValue:forKey:)])
+                _crashlytics = crashlyticsInstance;
         }
     }
     return self;

--- a/Branch-SDK/Branch-SDK/BNCCrashlyticsWrapper.m
+++ b/Branch-SDK/Branch-SDK/BNCCrashlyticsWrapper.m
@@ -1,0 +1,53 @@
+//
+//  BNCCrashlyticsReportingHelper.m
+//  Branch.framework
+//
+//  Created by Jimmy Dee on 7/18/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import "BNCCrashlyticsWrapper.h"
+
+@interface BNCCrashlyticsWrapper()
+@property (nonatomic, nullable) id crashlytics;
+@end
+
+@implementation BNCCrashlyticsWrapper
+
++ (id)sharedInstance
+{
+    // This just exists so that sharedInstance is not an unknown selector.
+    return nil;
+}
+
++ (instancetype)wrapper
+{
+    return [[self alloc] init];
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        // Dynamically obtain Crashlytics.sharedInstance if the Crashlytics SDK is linked.
+        Class Crashlytics = NSClassFromString(@"Crashlytics");
+        if (Crashlytics) {
+            if ([Crashlytics respondsToSelector:@selector(sharedInstance)]) {
+                id crashlyticsInstance = [Crashlytics sharedInstance];
+                if ([crashlyticsInstance isKindOfClass:Crashlytics] &&
+                    [crashlyticsInstance respondsToSelector:@selector(setObjectValue:forKey:)])
+                    _crashlytics = crashlyticsInstance;
+            }
+        }
+    }
+    return self;
+}
+
+- (void)setObjectValue:(id)value forKey:(NSString *)key
+{
+    if (!self.crashlytics) return;
+
+    [self.crashlytics setObjectValue:value forKey:key];
+}
+
+@end

--- a/Branch-SDK/Branch-SDK/BNCCrashlyticsWrapper.m
+++ b/Branch-SDK/Branch-SDK/BNCCrashlyticsWrapper.m
@@ -35,7 +35,10 @@
             if ([Crashlytics respondsToSelector:@selector(sharedInstance)]) {
                 id crashlyticsInstance = [Crashlytics sharedInstance];
                 if ([crashlyticsInstance isKindOfClass:Crashlytics] &&
-                    [crashlyticsInstance respondsToSelector:@selector(setObjectValue:forKey:)])
+                    [crashlyticsInstance respondsToSelector:@selector(setObjectValue:forKey:)] &&
+                    [crashlyticsInstance respondsToSelector:@selector(setBoolValue:forKey:)] &&
+                    [crashlyticsInstance respondsToSelector:@selector(setFloatValue:forKey:)] &&
+                    [crashlyticsInstance respondsToSelector:@selector(setIntValue:forKey:)])
                     _crashlytics = crashlyticsInstance;
             }
         }
@@ -46,8 +49,25 @@
 - (void)setObjectValue:(id)value forKey:(NSString *)key
 {
     if (!self.crashlytics) return;
-
     [self.crashlytics setObjectValue:value forKey:key];
+}
+
+- (void)setIntValue:(int)value forKey:(NSString *)key
+{
+    if (!self.crashlytics) return;
+    [self.crashlytics setIntValue:value forKey:key];
+}
+
+- (void)setFloatValue:(float)value forKey:(NSString *)key
+{
+    if (!self.crashlytics) return;
+    [self.crashlytics setFloatValue:value forKey:key];
+}
+
+- (void)setBoolValue:(BOOL)value forKey:(NSString *)key
+{
+    if (!self.crashlytics) return;
+    [self.crashlytics setBoolValue:value forKey:key];
 }
 
 @end

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -189,9 +189,20 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  * prevent reporting the device fingerprint ID to Crashlytics, call
  * [Branch setDisableFingerPrintIDInCrashlyticsReports:YES] before
  * [Branch getInstance] or [Branch getTestInstance].
+ *
+ * This method is thread-safe.
+ *
+ * @param disabled Set to YES to disable reporting of the device fingerprint ID to Crashlytics.
  */
 + (void) setDisableFingerprintIDInCrashlyticsReports:(BOOL)disabled;
 
+/**
+ * Determine whether device fingerprint ID reporting to Crashlytics is disabled.
+ *
+ * This method is thread-safe.
+ *
+ * @return YES if device fingerprint ID reporting to Crashlytics is disabled. NO otherwise.
+ */
 + (BOOL) disableFingerprintIDInCrashlyticsReports;
 
 #pragma mark - BranchActivityItemProvider methods

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -183,6 +183,17 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
 /// @return Returns the current Branch key.
 + (NSString*) branchKey;
 
+/**
+ * By default, the Branch SDK will include the device fingerprint ID as metadata in Crashlytics
+ * reports. This can help locate problems by correlating API traffic with a crash. To
+ * prevent reporting the device fingerprint ID to Crashlytics, call
+ * [Branch setDisableFingerPrintIDInCrashlyticsReports:YES] before
+ * [Branch getInstance] or [Branch getTestInstance].
+ */
++ (void) setDisableFingerprintIDInCrashlyticsReports:(BOOL)disabled;
+
++ (BOOL) disableFingerprintIDInCrashlyticsReports;
+
 #pragma mark - BranchActivityItemProvider methods
 
 ///-----------------------------------------

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -187,23 +187,23 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  * By default, the Branch SDK will include the device fingerprint ID as metadata in Crashlytics
  * reports. This can help locate problems by correlating API traffic with a crash. To
  * prevent reporting the device fingerprint ID to Crashlytics, call
- * [Branch setDisableFingerPrintIDInCrashlyticsReports:YES] before
+ * [Branch setEnableFingerPrintIDInCrashlyticsReports:NO] before
  * [Branch getInstance] or [Branch getTestInstance].
  *
  * This method is thread-safe.
  *
- * @param disabled Set to YES to disable reporting of the device fingerprint ID to Crashlytics.
+ * @param enabled Set to NO to disable reporting of the device fingerprint ID to Crashlytics.
  */
-+ (void) setDisableFingerprintIDInCrashlyticsReports:(BOOL)disabled;
++ (void) setEnableFingerprintIDInCrashlyticsReports:(BOOL)enabled;
 
 /**
- * Determine whether device fingerprint ID reporting to Crashlytics is disabled.
+ * Determine whether device fingerprint ID reporting to Crashlytics is enabled.
  *
  * This method is thread-safe.
  *
- * @return YES if device fingerprint ID reporting to Crashlytics is disabled. NO otherwise.
+ * @return YES if device fingerprint ID reporting to Crashlytics is enabled. NO otherwise.
  */
-+ (BOOL) disableFingerprintIDInCrashlyticsReports;
++ (BOOL) enableFingerprintIDInCrashlyticsReports;
 
 #pragma mark - BranchActivityItemProvider methods
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1269,7 +1269,10 @@ static NSString *bnc_branchKey = nil;
             
             [[BNCServerRequestQueue getInstance] clearQueue];
         }
-        
+        BNCCrashlyticsWrapper *crashlytics = [BNCCrashlyticsWrapper wrapper];
+        // may be nil
+        [crashlytics setObjectValue:preferenceHelper.deviceFingerprintID forKey:@"io.branch.device.fingerprintid"];
+
         preferenceHelper.lastRunBranchKey = key;
         
         branch = [[Branch alloc] initWithInterface:[[BNCServerInterface alloc] init] queue:[BNCServerRequestQueue getInstance] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:key];

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -213,7 +213,7 @@ void ForceCategoriesToLoad(void) {
 
 static BOOL bnc_useTestBranchKey = NO;
 static NSString *bnc_branchKey = nil;
-static BOOL bnc_disableFingerprintIDInCrashlyticsReports = NO;
+static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
 
 + (void) setUseTestBranchKey:(BOOL)useTestKey {
     @synchronized (self) {
@@ -300,17 +300,17 @@ static BOOL bnc_disableFingerprintIDInCrashlyticsReports = NO;
     }
 }
 
-+ (void)setDisableFingerprintIDInCrashlyticsReports:(BOOL)disabled
++ (void)setEnableFingerprintIDInCrashlyticsReports:(BOOL)enabled
 {
     @synchronized(self) {
-        bnc_disableFingerprintIDInCrashlyticsReports = disabled;
+        bnc_enableFingerprintIDInCrashlyticsReports = enabled;
     }
 }
 
-+ (BOOL) disableFingerprintIDInCrashlyticsReports
++ (BOOL) enableFingerprintIDInCrashlyticsReports
 {
     @synchronized (self) {
-        return bnc_disableFingerprintIDInCrashlyticsReports;
+        return bnc_enableFingerprintIDInCrashlyticsReports;
     }
 }
 
@@ -1289,7 +1289,7 @@ static BOOL bnc_disableFingerprintIDInCrashlyticsReports = NO;
             [[BNCServerRequestQueue getInstance] clearQueue];
         }
 
-        if (!self.disableFingerprintIDInCrashlyticsReports) {
+        if (self.enableFingerprintIDInCrashlyticsReports) {
             BNCCrashlyticsWrapper *crashlytics = [BNCCrashlyticsWrapper wrapper];
             // may be nil
             [crashlytics setObjectValue:preferenceHelper.deviceFingerprintID forKey:BRANCH_CRASHLYTICS_FINGERPRINT_ID_KEY];

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -124,7 +124,7 @@ void ForceCategoriesToLoad(void) {
         BNCLogSetOutputToURLByteWrap(logURL,  102400);
         BNCLogSetDisplayLevel(BNCLogLevelWarning);
         BNCLogDebug(@"Branch version %@ started at %@.", BNC_SDK_VERSION, [NSDate date]);
-        [self enhanceCrashlyticsReports];
+        [self logLowMemoryToCrashlytics];
     }
 }
 
@@ -1909,12 +1909,8 @@ void BNCPerformBlockOnMainThread(dispatch_block_t block) {
 
 #pragma mark - Crashlytics reporting enhancements
 
-+ (void)enhanceCrashlyticsReports
++ (void)logLowMemoryToCrashlytics
 {
-    /* Not consistently showing up. Moving to a later method.
-    [self addBranchSDKVersionToCrashlyticsReport];
-    // */
-
     [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidReceiveMemoryWarningNotification
                                                     object:nil
                                                      queue:NSOperationQueue.mainQueue

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -20,6 +20,7 @@
 #import "BNCContentDiscoveryManager.h"
 #import "BNCStrongMatchHelper.h"
 #import "BNCDeepLinkViewControllerInstance.h"
+#import "BNCCrashlyticsWrapper.h"
 #import "BranchUniversalObject.h"
 #import "BranchSetIdentityRequest.h"
 #import "BranchLogoutRequest.h"
@@ -122,6 +123,7 @@ void ForceCategoriesToLoad(void) {
         BNCLogSetOutputToURLByteWrap(logURL,  102400);
         BNCLogSetDisplayLevel(BNCLogLevelWarning);
         BNCLogDebug(@"Branch version %@ started at %@.", BNC_SDK_VERSION, [NSDate date]);
+        [self enhanceCrashlyticsReports];
     }
 }
 
@@ -1878,6 +1880,14 @@ void BNCPerformBlockOnMainThread(dispatch_block_t block) {
 
 + (NSString *)kitDisplayVersion {
 	return BNC_SDK_VERSION;
+}
+
+#pragma mark - Crashlytics reporting enhancements
+
++ (void)enhanceCrashlyticsReports
+{
+    BNCCrashlyticsWrapper *crashlytics = [BNCCrashlyticsWrapper wrapper];
+    [crashlytics setObjectValue:BNC_SDK_VERSION forKey:@"io.branch.sdk.version"];
 }
 
 @end

--- a/Branch-SDK/Branch-SDK/BranchConstants.h
+++ b/Branch-SDK/Branch-SDK/BranchConstants.h
@@ -133,3 +133,7 @@ extern NSString * const BRANCH_PACKAGE_NAME_KEY;
 extern NSString * const BRANCH_ENTITIES_KEY;
 
 extern NSString * const BRANCH_REQUEST_KEY_SEARCH_AD;
+
+extern NSString * const BRANCH_CRASHLYTICS_SDK_VERSION_KEY;
+extern NSString * const BRANCH_CRASHLYTICS_FINGERPRINT_ID_KEY;
+extern NSString * const BRANCH_CRASHLYTICS_LOW_MEMORY_KEY;

--- a/Branch-SDK/Branch-SDK/BranchConstants.m
+++ b/Branch-SDK/Branch-SDK/BranchConstants.m
@@ -133,3 +133,6 @@ NSString * const BRANCH_ENTITIES_KEY = @"e";
 
 NSString * const BRANCH_REQUEST_KEY_SEARCH_AD = @"search_ad_encoded";
 
+NSString * const BRANCH_CRASHLYTICS_SDK_VERSION_KEY = @"io.branch.sdk.version";
+NSString * const BRANCH_CRASHLYTICS_FINGERPRINT_ID_KEY = @"io.branch.device.fingerprintid";
+NSString * const BRANCH_CRASHLYTICS_LOW_MEMORY_KEY = @"io.branch.device.lowmemory";

--- a/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
@@ -11,6 +11,7 @@
 #import "BNCPreferenceHelper.h"
 #import "BNCSystemObserver.h"
 #import "BNCDeviceInfo.h"
+#import "BNCCrashlyticsWrapper.h"
 #import "BranchConstants.h"
 #import "BNCEncodingUtils.h"
 #import "BranchViewHandler.h"
@@ -107,6 +108,11 @@
     preferenceHelper.userIdentity = userIdentity;
     preferenceHelper.sessionID = data[BRANCH_RESPONSE_KEY_SESSION_ID];
     [BNCSystemObserver setUpdateState];
+
+    if (!Branch.disableFingerprintIDInCrashlyticsReports) {
+        BNCCrashlyticsWrapper *crashlytics = [BNCCrashlyticsWrapper wrapper];
+        [crashlytics setObjectValue:preferenceHelper.deviceFingerprintID forKey:BRANCH_CRASHLYTICS_FINGERPRINT_ID_KEY];
+    }
 
     NSString *sessionData = data[BRANCH_RESPONSE_KEY_SESSION_DATA];
 

--- a/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
@@ -109,7 +109,7 @@
     preferenceHelper.sessionID = data[BRANCH_RESPONSE_KEY_SESSION_ID];
     [BNCSystemObserver setUpdateState];
 
-    if (!Branch.disableFingerprintIDInCrashlyticsReports) {
+    if (Branch.enableFingerprintIDInCrashlyticsReports) {
         BNCCrashlyticsWrapper *crashlytics = [BNCCrashlyticsWrapper wrapper];
         [crashlytics setObjectValue:preferenceHelper.deviceFingerprintID forKey:BRANCH_CRASHLYTICS_FINGERPRINT_ID_KEY];
     }

--- a/Branch-TestBed-Swift/TestBed-Swift.xcodeproj/project.pbxproj
+++ b/Branch-TestBed-Swift/TestBed-Swift.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		63F65BFA1D654EF30055A2F6 /* DictionaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F65BF91D654EF30055A2F6 /* DictionaryTableViewCell.swift */; };
 		63F8BB201D57D2BE0013B6F7 /* LinkPropertiesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8BB1F1D57D2BE0013B6F7 /* LinkPropertiesTableViewController.swift */; };
 		63F8BB241D57E7730013B6F7 /* ArrayTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8BB231D57E7730013B6F7 /* ArrayTableViewController.swift */; };
+		7B18DF4D1F1F016600C25C84 /* BNCCrashlyticsWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B18DF4C1F1F016600C25C84 /* BNCCrashlyticsWrapper.m */; };
 		F155BFF21EF37EEA00BF4566 /* BNCDeepLinkViewControllerInstance.m in Sources */ = {isa = PBXBuildFile; fileRef = F155BFF11EF37EEA00BF4566 /* BNCDeepLinkViewControllerInstance.m */; };
 /* End PBXBuildFile section */
 
@@ -215,6 +216,8 @@
 		63F65BF91D654EF30055A2F6 /* DictionaryTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryTableViewCell.swift; sourceTree = "<group>"; };
 		63F8BB1F1D57D2BE0013B6F7 /* LinkPropertiesTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkPropertiesTableViewController.swift; sourceTree = "<group>"; };
 		63F8BB231D57E7730013B6F7 /* ArrayTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayTableViewController.swift; sourceTree = "<group>"; };
+		7B18DF4B1F1F016600C25C84 /* BNCCrashlyticsWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCCrashlyticsWrapper.h; sourceTree = "<group>"; };
+		7B18DF4C1F1F016600C25C84 /* BNCCrashlyticsWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCCrashlyticsWrapper.m; sourceTree = "<group>"; };
 		F155BFED1EF37EDB00BF4566 /* BNCLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCLog.h; sourceTree = "<group>"; };
 		F155BFF01EF37EEA00BF4566 /* BNCDeepLinkViewControllerInstance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCDeepLinkViewControllerInstance.h; sourceTree = "<group>"; };
 		F155BFF11EF37EEA00BF4566 /* BNCDeepLinkViewControllerInstance.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCDeepLinkViewControllerInstance.m; sourceTree = "<group>"; };
@@ -264,6 +267,8 @@
 				4D4F27E21E400F9800282A34 /* BNCConfig.m */,
 				4D4F27E31E400F9800282A34 /* BNCContentDiscoveryManager.h */,
 				4D4F27E41E400F9800282A34 /* BNCContentDiscoveryManager.m */,
+				7B18DF4B1F1F016600C25C84 /* BNCCrashlyticsWrapper.h */,
+				7B18DF4C1F1F016600C25C84 /* BNCCrashlyticsWrapper.m */,
 				4DB47D581F042C5900C53C29 /* BNCDebug.h */,
 				4DB47D591F042C5900C53C29 /* BNCDebug.m */,
 				F155BFF01EF37EEA00BF4566 /* BNCDeepLinkViewControllerInstance.h */,
@@ -573,6 +578,7 @@
 				4D4F284B1E400F9800282A34 /* BNCStrongMatchHelper.m in Sources */,
 				4D4F28651E400F9800282A34 /* BranchShortUrlSyncRequest.m in Sources */,
 				63F8BB241D57E7730013B6F7 /* ArrayTableViewController.swift in Sources */,
+				7B18DF4D1F1F016600C25C84 /* BNCCrashlyticsWrapper.m in Sources */,
 				63AAF1011CF7F58900CA98BD /* ContentViewController.swift in Sources */,
 				63F8BB201D57D2BE0013B6F7 /* LinkPropertiesTableViewController.swift in Sources */,
 				6306FFF11D6BEFA30031D2E3 /* ArrayTableViewCell.swift in Sources */,

--- a/Branch-TestBed-Xcode-7/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed-Xcode-7/Branch-TestBed.xcodeproj/project.pbxproj
@@ -135,6 +135,9 @@
 		67486B8E1B93B48A0044D872 /* BNCStrongMatchHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 67486B8C1B93B48A0044D872 /* BNCStrongMatchHelper.m */; };
 		677F4CB51C1FB1910029F2B3 /* Branch-TestBed.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 677F4CB41C1FB0FA0029F2B3 /* Branch-TestBed.entitlements */; };
 		67F270891BA9FCFF002546A7 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		7BE8B08A1F215B6E003790B7 /* BNCCrashlyticsWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE8B0881F215B6E003790B7 /* BNCCrashlyticsWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BE8B08B1F215B6E003790B7 /* BNCCrashlyticsWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BE8B0891F215B6E003790B7 /* BNCCrashlyticsWrapper.m */; };
+		7BE8B08E1F215D30003790B7 /* BNCCrashlyticsWrapper.Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BE8B08C1F215BE8003790B7 /* BNCCrashlyticsWrapper.Test.m */; };
 		7D0C97191D8753C9004E14B1 /* BranchContentDiscoverer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C97181D8753C9004E14B1 /* BranchContentDiscoverer.m */; };
 		7D0C971D1D875465004E14B1 /* BranchContentDiscoveryManifest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C971C1D875465004E14B1 /* BranchContentDiscoveryManifest.m */; };
 		7D0C97201D87549B004E14B1 /* BranchContentPathProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C971F1D87549B004E14B1 /* BranchContentPathProperties.m */; };
@@ -296,6 +299,9 @@
 		67BBCF271A69E49A009C7DAE /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSpotlight.framework; path = System/Library/Frameworks/CoreSpotlight.framework; sourceTree = SDKROOT; };
 		69347EDA2E4ED874ED5DA0B3 /* Pods-Branch-SDK-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Branch-SDK-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Branch-SDK-Tests/Pods-Branch-SDK-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		7BE8B0881F215B6E003790B7 /* BNCCrashlyticsWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCCrashlyticsWrapper.h; sourceTree = "<group>"; };
+		7BE8B0891F215B6E003790B7 /* BNCCrashlyticsWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCCrashlyticsWrapper.m; sourceTree = "<group>"; };
+		7BE8B08C1F215BE8003790B7 /* BNCCrashlyticsWrapper.Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCCrashlyticsWrapper.Test.m; sourceTree = "<group>"; };
 		7D0C97181D8753C9004E14B1 /* BranchContentDiscoverer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchContentDiscoverer.m; sourceTree = "<group>"; };
 		7D0C971A1D8753EA004E14B1 /* BranchContentDiscoverer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoverer.h; sourceTree = "<group>"; };
 		7D0C971B1D875445004E14B1 /* BranchContentDiscoveryManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoveryManifest.h; sourceTree = "<group>"; };
@@ -522,6 +528,8 @@
 				4D3FA94A1DFF31EB00E2B6A9 /* BNCConfig.m */,
 				466D5A0F1B5991E3009DB845 /* BNCContentDiscoveryManager.h */,
 				466D5A101B5991E3009DB845 /* BNCContentDiscoveryManager.m */,
+				7BE8B0881F215B6E003790B7 /* BNCCrashlyticsWrapper.h */,
+				7BE8B0891F215B6E003790B7 /* BNCCrashlyticsWrapper.m */,
 				4D44E7C31E68F34E00793D79 /* BNCDebug.h */,
 				4D44E7C41E68F34E00793D79 /* BNCDebug.m */,
 				4D60C7741F0D66280090DD5B /* BNCDeepLinkViewControllerInstance.h */,
@@ -600,6 +608,7 @@
 		7E6B3B521AA42D0E005F45BF /* Branch-SDK-Tests */ = {
 			isa = PBXGroup;
 			children = (
+				7BE8B08C1F215BE8003790B7 /* BNCCrashlyticsWrapper.Test.m */,
 				4D44E7BC1E68F31B00793D79 /* BNCDebug.Test.m */,
 				46FFCF161ACC321A00039CE0 /* BNCEncodingUtilsTests.m */,
 				46DBB42B1B330CF300642FC8 /* BNCLinkDataTests.m */,
@@ -696,6 +705,7 @@
 				67486B8D1B93B48A0044D872 /* BNCStrongMatchHelper.h in Headers */,
 				46946BA31B2689A100627BCC /* BranchOpenRequest.h in Headers */,
 				46946BA41B2689A100627BCC /* BranchInstallRequest.h in Headers */,
+				7BE8B08A1F215B6E003790B7 /* BNCCrashlyticsWrapper.h in Headers */,
 				46946B861B26898B00627BCC /* BranchSetIdentityRequest.h in Headers */,
 				4D44E7CB1E68F34E00793D79 /* BNCLog.h in Headers */,
 				466B58771B17780A00A69EDE /* BNCSystemObserver.h in Headers */,
@@ -792,6 +802,7 @@
 					7E6B3B501AA42D0E005F45BF = {
 						CreatedOnToolsVersion = 6.1.1;
 						DevelopmentTeam = R63EM248DP;
+						TestTargetID = 6700165F1940F51400A9E103;
 					};
 				};
 			};
@@ -922,6 +933,7 @@
 				463F0A421B20A663004235D2 /* BranchInstallRequest.m in Sources */,
 				4D35141C1E3201D80085EBA1 /* NSMutableDictionary+Branch.m in Sources */,
 				7D0C97191D8753C9004E14B1 /* BranchContentDiscoverer.m in Sources */,
+				7BE8B08B1F215B6E003790B7 /* BNCCrashlyticsWrapper.m in Sources */,
 				466B58661B17779C00A69EDE /* BNCServerResponse.m in Sources */,
 				466B58681B17779C00A69EDE /* BNCLinkData.m in Sources */,
 				54FF1F921BD1DC320004CE2E /* BranchLinkProperties.m in Sources */,
@@ -968,6 +980,7 @@
 				4D8DFD971EC6399F00D47413 /* BNCTestCase.m in Sources */,
 				4665AF281B28C1DE00184037 /* BranchLogoutRequestTests.m in Sources */,
 				46DC40781B2B549F00D2D203 /* BranchGetCreditHistoryRequestTests.m in Sources */,
+				7BE8B08E1F215D30003790B7 /* BNCCrashlyticsWrapper.Test.m in Sources */,
 				4D44E7D01E68F39300793D79 /* BNCLog.Test.m in Sources */,
 				464EA3981ACB1797000E4094 /* BNCServerInterfaceTests.m in Sources */,
 				4665AF241B28B7E000184037 /* BranchSetIdentityRequestTests.m in Sources */,
@@ -1195,6 +1208,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BD1915E2CE30909947ECEB14 /* Pods-Branch-SDK-Tests.debug.xcconfig */;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				DEVELOPMENT_TEAM = R63EM248DP;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1206,6 +1220,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.sdk.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Branch-TestBed.app/Branch-TestBed";
 			};
 			name = Debug;
 		};
@@ -1213,6 +1228,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 69347EDA2E4ED874ED5DA0B3 /* Pods-Branch-SDK-Tests.release.xcconfig */;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				DEVELOPMENT_TEAM = R63EM248DP;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1220,6 +1236,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.sdk.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Branch-TestBed.app/Branch-TestBed";
 			};
 			name = Release;
 		};

--- a/Branch-TestBed-Xcode-7/Branch-TestBed.xcodeproj/xcshareddata/xcschemes/Branch-TestBed.xcscheme
+++ b/Branch-TestBed-Xcode-7/Branch-TestBed.xcodeproj/xcshareddata/xcschemes/Branch-TestBed.xcscheme
@@ -21,7 +21,7 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "NO"
+            buildForTesting = "YES"
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
@@ -43,6 +43,16 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7E6B3B501AA42D0E005F45BF"
+               BuildableName = "Branch-SDK-Tests.xctest"
+               BlueprintName = "Branch-SDK-Tests"
+               ReferencedContainer = "container:Branch-TestBed.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Branch-TestBed-iMessage/Branch-TestBed-iMessage.xcodeproj/project.pbxproj
+++ b/Branch-TestBed-iMessage/Branch-TestBed-iMessage.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		67E91FD91D769FE30039F1C4 /* BranchShortUrlSyncRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 67E91FAC1D769FE30039F1C4 /* BranchShortUrlSyncRequest.m */; };
 		67E91FDA1D769FE30039F1C4 /* BranchSpotlightUrlRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 67E91FAE1D769FE30039F1C4 /* BranchSpotlightUrlRequest.m */; };
 		67E91FDB1D769FE30039F1C4 /* BranchUserCompletedActionRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 67E91FB01D769FE30039F1C4 /* BranchUserCompletedActionRequest.m */; };
+		7B18DF501F1F028600C25C84 /* BNCCrashlyticsWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B18DF4F1F1F028600C25C84 /* BNCCrashlyticsWrapper.m */; };
 		E212CC5E1D9DE6A900603475 /* BranchContentDiscoveryManifest.m in Sources */ = {isa = PBXBuildFile; fileRef = E212CC5D1D9DE6A900603475 /* BranchContentDiscoveryManifest.m */; };
 		E212CC611D9DE6C400603475 /* BranchContentPathProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = E212CC601D9DE6C400603475 /* BranchContentPathProperties.m */; };
 		E212CC641D9DE6D800603475 /* BranchContentDiscoverer.m in Sources */ = {isa = PBXBuildFile; fileRef = E212CC631D9DE6D800603475 /* BranchContentDiscoverer.m */; };
@@ -195,6 +196,8 @@
 		67E91FB61D769FE30039F1C4 /* FABKitProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FABKitProtocol.h; sourceTree = "<group>"; };
 		67E91FB71D769FE30039F1C4 /* Fabric+FABKits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
 		67E91FB81D769FE30039F1C4 /* Fabric.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
+		7B18DF4E1F1F028600C25C84 /* BNCCrashlyticsWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCCrashlyticsWrapper.h; sourceTree = "<group>"; };
+		7B18DF4F1F1F028600C25C84 /* BNCCrashlyticsWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCCrashlyticsWrapper.m; sourceTree = "<group>"; };
 		E212CC5C1D9DE6A900603475 /* BranchContentDiscoveryManifest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoveryManifest.h; sourceTree = "<group>"; };
 		E212CC5D1D9DE6A900603475 /* BranchContentDiscoveryManifest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchContentDiscoveryManifest.m; sourceTree = "<group>"; };
 		E212CC5F1D9DE6C400603475 /* BranchContentPathProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchContentPathProperties.h; sourceTree = "<group>"; };
@@ -284,6 +287,8 @@
 				4D698FF01E04B566006DA451 /* BNCConfig.m */,
 				67E91F681D769FE30039F1C4 /* BNCContentDiscoveryManager.h */,
 				67E91F691D769FE30039F1C4 /* BNCContentDiscoveryManager.m */,
+				7B18DF4E1F1F028600C25C84 /* BNCCrashlyticsWrapper.h */,
+				7B18DF4F1F1F028600C25C84 /* BNCCrashlyticsWrapper.m */,
 				4DB47D4C1F042BB900C53C29 /* BNCDebug.h */,
 				4DB47D4D1F042BB900C53C29 /* BNCDebug.m */,
 				4D510D741F0D6059003D720B /* BNCDeepLinkViewControllerInstance.h */,
@@ -524,6 +529,7 @@
 				67E91FD01D769FE30039F1C4 /* BranchCreditHistoryRequest.m in Sources */,
 				67E91FD51D769FE30039F1C4 /* BranchRedeemRewardsRequest.m in Sources */,
 				67E91FC41D769FE30039F1C4 /* BNCStrongMatchHelper.m in Sources */,
+				7B18DF501F1F028600C25C84 /* BNCCrashlyticsWrapper.m in Sources */,
 				4DB567371E79FD5E00A8A324 /* BranchShareLink.m in Sources */,
 				67E91FD21D769FE30039F1C4 /* BranchLoadRewardsRequest.m in Sources */,
 				4D698FF21E04B566006DA451 /* BNCConfig.m in Sources */,

--- a/Branch-TestBed/Branch-SDK-Tests/BNCCrashlyticsWrapper.Test.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCCrashlyticsWrapper.Test.m
@@ -1,0 +1,53 @@
+//
+//  BNCCrashlyticsWrapperTest.m
+//  Branch-TestBed
+//
+//  Created by Jimmy Dee on 7/18/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import "BNCCrashlyticsWrapper.h"
+#import "BNCTestCase.h"
+#import <OCMock/OCMock.h>
+
+// stand-in for Crashlytics SDK
+@interface Crashlytics : NSObject
++ (Crashlytics *)sharedInstance;
+
+- (void)setObjectValue:(id)value forKey:(NSString *)key;
+@end
+
+@implementation Crashlytics
++ (Crashlytics *)sharedInstance
+{
+    return [[self alloc] init];
+}
+
+- (void)setObjectValue:(id)value forKey:(NSString *)key
+{
+}
+@end
+
+// test case
+@interface BNCCrashlyticsWrapperTest : BNCTestCase
+@end
+
+@implementation BNCCrashlyticsWrapperTest
+
+- (void)testInitialization
+{
+    id classMock = OCMClassMock(Crashlytics.class);
+    Crashlytics *expected = [[Crashlytics alloc] init];
+
+    OCMStub([classMock sharedInstance]).andReturn(expected);
+
+    BNCCrashlyticsWrapper *wrapper = [BNCCrashlyticsWrapper wrapper];
+    Crashlytics *actual = wrapper.crashlytics;
+
+    // The crashlytics property is whatever sharedInstance returns
+    XCTAssertEqual(expected, actual);
+}
+
+// TODO: Test setObjectValue:forKey:
+
+@end

--- a/Branch-TestBed/Branch-SDK-Tests/BNCCrashlyticsWrapper.Test.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCCrashlyticsWrapper.Test.m
@@ -26,6 +26,18 @@
 - (void)setObjectValue:(id)value forKey:(NSString *)key
 {
 }
+
+- (void)setIntValue:(int)value forKey:(NSString *)key
+{
+}
+
+- (void)setFloatValue:(float)value forKey:(NSString *)key
+{
+}
+
+- (void)setBoolValue:(BOOL)value forKey:(NSString *)key
+{
+}
 @end
 
 // test case

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -130,6 +130,9 @@
 		67486B8E1B93B48A0044D872 /* BNCStrongMatchHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 67486B8C1B93B48A0044D872 /* BNCStrongMatchHelper.m */; };
 		677F4CB51C1FB1910029F2B3 /* Branch-TestBed.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 677F4CB41C1FB0FA0029F2B3 /* Branch-TestBed.entitlements */; };
 		67F270891BA9FCFF002546A7 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		7B18DF491F1F00E200C25C84 /* BNCCrashlyticsWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B18DF471F1F00E200C25C84 /* BNCCrashlyticsWrapper.h */; };
+		7B18DF4A1F1F00E200C25C84 /* BNCCrashlyticsWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B18DF481F1F00E200C25C84 /* BNCCrashlyticsWrapper.m */; };
+		7B18DF521F1F049F00C25C84 /* BNCCrashlyticsWrapper.Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B18DF511F1F049F00C25C84 /* BNCCrashlyticsWrapper.Test.m */; };
 		7D0C97191D8753C9004E14B1 /* BranchContentDiscoverer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C97181D8753C9004E14B1 /* BranchContentDiscoverer.m */; };
 		7D0C971D1D875465004E14B1 /* BranchContentDiscoveryManifest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C971C1D875465004E14B1 /* BranchContentDiscoveryManifest.m */; };
 		7D0C97201D87549B004E14B1 /* BranchContentPathProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C971F1D87549B004E14B1 /* BranchContentPathProperties.m */; };
@@ -285,6 +288,9 @@
 		67BBCF271A69E49A009C7DAE /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSpotlight.framework; path = System/Library/Frameworks/CoreSpotlight.framework; sourceTree = SDKROOT; };
 		69347EDA2E4ED874ED5DA0B3 /* Pods-Branch-SDK-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Branch-SDK-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Branch-SDK-Tests/Pods-Branch-SDK-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		7B18DF471F1F00E200C25C84 /* BNCCrashlyticsWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCCrashlyticsWrapper.h; sourceTree = "<group>"; };
+		7B18DF481F1F00E200C25C84 /* BNCCrashlyticsWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCCrashlyticsWrapper.m; sourceTree = "<group>"; };
+		7B18DF511F1F049F00C25C84 /* BNCCrashlyticsWrapper.Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCCrashlyticsWrapper.Test.m; sourceTree = "<group>"; };
 		7D0C97181D8753C9004E14B1 /* BranchContentDiscoverer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchContentDiscoverer.m; sourceTree = "<group>"; };
 		7D0C971A1D8753EA004E14B1 /* BranchContentDiscoverer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoverer.h; sourceTree = "<group>"; };
 		7D0C971B1D875445004E14B1 /* BranchContentDiscoveryManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoveryManifest.h; sourceTree = "<group>"; };
@@ -512,6 +518,8 @@
 				4D3FA94A1DFF31EB00E2B6A9 /* BNCConfig.m */,
 				466D5A0F1B5991E3009DB845 /* BNCContentDiscoveryManager.h */,
 				466D5A101B5991E3009DB845 /* BNCContentDiscoveryManager.m */,
+				7B18DF471F1F00E200C25C84 /* BNCCrashlyticsWrapper.h */,
+				7B18DF481F1F00E200C25C84 /* BNCCrashlyticsWrapper.m */,
 				4DA5771B1E67B22700A43BDD /* BNCDebug.h */,
 				4DA5771C1E67B22700A43BDD /* BNCDebug.m */,
 				7D5882301CA1BEEA00FF6358 /* BNCDeviceInfo.h */,
@@ -590,6 +598,7 @@
 		7E6B3B521AA42D0E005F45BF /* Branch-SDK-Tests */ = {
 			isa = PBXGroup;
 			children = (
+				7B18DF511F1F049F00C25C84 /* BNCCrashlyticsWrapper.Test.m */,
 				4DA5771E1E67B23D00A43BDD /* BNCDebug.Test.m */,
 				46FFCF161ACC321A00039CE0 /* BNCEncodingUtilsTests.m */,
 				46DBB42B1B330CF300642FC8 /* BNCLinkDataTests.m */,
@@ -680,6 +689,7 @@
 				466B587B1B17780A00A69EDE /* BNCServerResponse.h in Headers */,
 				460F4FA71B618A38002E84D6 /* BranchSpotlightUrlRequest.h in Headers */,
 				466B587F1B17780A00A69EDE /* BNCEncodingUtils.h in Headers */,
+				7B18DF491F1F00E200C25C84 /* BNCCrashlyticsWrapper.h in Headers */,
 				54FF1F911BD1DC320004CE2E /* BranchLinkProperties.h in Headers */,
 				67486B8D1B93B48A0044D872 /* BNCStrongMatchHelper.h in Headers */,
 				46946BA31B2689A100627BCC /* BranchOpenRequest.h in Headers */,
@@ -879,6 +889,7 @@
 			files = (
 				463F0A311B20A663004235D2 /* BNCServerRequest.m in Sources */,
 				7D58823A1CA1DF2700FF6358 /* BNCDeviceInfo.m in Sources */,
+				7B18DF4A1F1F00E200C25C84 /* BNCCrashlyticsWrapper.m in Sources */,
 				7D0C971D1D875465004E14B1 /* BranchContentDiscoveryManifest.m in Sources */,
 				466D5A121B5991E3009DB845 /* BNCContentDiscoveryManager.m in Sources */,
 				466B58551B17779C00A69EDE /* Branch.m in Sources */,
@@ -958,6 +969,7 @@
 				464EA3981ACB1797000E4094 /* BNCServerInterfaceTests.m in Sources */,
 				4665AF241B28B7E000184037 /* BranchSetIdentityRequestTests.m in Sources */,
 				46DBB42D1B330CF300642FC8 /* BNCLinkDataTests.m in Sources */,
+				7B18DF521F1F049F00C25C84 /* BNCCrashlyticsWrapper.Test.m in Sources */,
 				46DC40741B2B31A300D2D203 /* BranchLoadRewardsRequestTests.m in Sources */,
 				46DC40701B2A34EE00D2D203 /* BranchUserCompletedActionTests.m in Sources */,
 				46D0B6FA1ACD8EF000CDDE82 /* BNCPreferenceHelperTests.m in Sources */,
@@ -1158,7 +1170,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.sdk.Branch-TestBed";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				USER_HEADER_SEARCH_PATHS = "$PROJECT_DIR";
+				USER_HEADER_SEARCH_PATHS = $PROJECT_DIR;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1179,7 +1191,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.sdk.Branch-TestBed";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				USER_HEADER_SEARCH_PATHS = "$PROJECT_DIR";
+				USER_HEADER_SEARCH_PATHS = $PROJECT_DIR;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;


### PR DESCRIPTION
This change adds several metadata keys to Crashlytics reports if the Crashlytics SDK is linked within the app. The BNCCrashlyticsWrapper method provides a number of methods to accomplish this. They are all no-ops if Crashlytics is not present in the app.

![screen shot 2017-07-21 at 11 14 01 am](https://user-images.githubusercontent.com/121951/28476712-da5f44f2-6e05-11e7-968f-465c614c5322.png)

The keys added are:

- **io.branch.sdk.version** The version of the Branch SDK (e.g. "0.16.2").
- **io.branch.device.fingerprintid** The value of `preferenceHelper.deviceFingerprintID`.
- **io.branch.device.lowmemory** Set to YES if a UIApplicationDidReceiveMemoryWarningNotification is received. Absent if no memory warning received.

Including the device fingerprint ID makes it possible, with some effort, to inspect all API traffic associated with a crash in order to help determine the cause. This seems like potentially sensitive information, so a new method was introduced: `[Branch setDisableFingerprintIDInCrashlyticsReports:YES]`, to be called before `[Branch getInstance]`. By default, the fingerprint ID will be included. This may be an excess of caution, since the Crashlytics SDK also has access to the IDFA and any other device info. This switch could be removed if desired. If it should be retained, it might be a good idea also to support it in the Info.plist to avoid issues with call order.

These metadata keys show up in individual sessions. We will not usually see them when reports are shared and will rely on partners to provide the information via screenshots or transcription, but this makes it possible to confirm the version of the SDK in any crash report and to identify all related session traffic afterward.
