### PR TITLE
Logging changes

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCLog.m
+++ b/Branch-SDK/Branch-SDK/BNCLog.m
@@ -416,7 +416,13 @@ void BNCLogSetOutputToURLByteWrap(NSURL *_Nullable URL, long maxBytes) {
 
 #pragma mark - Log Message Severity
 
-static BNCLogLevel bnc_LogDisplayLevel = BNCLogLevelWarning;
+#ifdef DEBUG
+#define BNC_DEFAULT_LOG_LEVEL BNCLogLevelDebug
+#else
+#define BNC_DEFAULT_LOG_LEVEL BNCLogLevelNone
+#endif // DEBUG
+
+static BNCLogLevel bnc_LogDisplayLevel = BNC_DEFAULT_LOG_LEVEL;
 
 BNCLogLevel BNCLogDisplayLevel() {
     @synchronized (bnc_LogIsInitialized) {
@@ -595,5 +601,39 @@ void BNCLogInitialize(void) {
         bnc_LogDateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
 
         bnc_LogIsInitialized = @(YES);
+
+        id logLevelEntry = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"branch_log_level"];
+        if (!logLevelEntry || ![logLevelEntry isKindOfClass:NSString.class]) return;
+
+        NSString *logLevelString = logLevelEntry;
+
+        // initialize the log level to whatever is specified in the Info.plist, if present
+        if ([logLevelString.lowercaseString isEqualToString:@"debugsdk"]) {
+            bnc_LogDisplayLevel = BNCLogLevelDebugSDK;
+        }
+        else if ([logLevelString.lowercaseString isEqualToString:@"breakpoint"]) {
+            bnc_LogDisplayLevel = BNCLogLevelBreakPoint;
+        }
+        else if ([logLevelString.lowercaseString isEqualToString:@"debug"]) {
+            bnc_LogDisplayLevel = BNCLogLevelDebug;
+        }
+        else if ([logLevelString.lowercaseString isEqualToString:@"warning"]) {
+            bnc_LogDisplayLevel = BNCLogLevelWarning;
+        }
+        else if ([logLevelString.lowercaseString isEqualToString:@"error"]) {
+            bnc_LogDisplayLevel = BNCLogLevelError;
+        }
+        else if ([logLevelString.lowercaseString isEqualToString:@"assert"]) {
+            bnc_LogDisplayLevel = BNCLogLevelAssert;
+        }
+        else if ([logLevelString.lowercaseString isEqualToString:@"log"]) {
+            bnc_LogDisplayLevel = BNCLogLevelLog;
+        }
+        else if ([logLevelString.lowercaseString isEqualToString:@"none"]) {
+            bnc_LogDisplayLevel = BNCLogLevelNone;
+        }
+        else {
+            // ignore for now. log somewhere?
+        }
     });
 }

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -22,6 +22,7 @@
 #import "BNCCommerceEvent.h"
 #import "BranchShareLink.h"
 #import "BNCXcode7Support.h"
+#import "BNCLog.h"
 
 /**
  `Branch` is the primary interface of the Branch iOS SDK. Currently, all interactions you will make are funneled through this class. It is not meant to be instantiated or subclassed, usage should be limited to the global instance.

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -20,6 +20,9 @@
 
 - (BOOL)application:(UIApplication *)application
 didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // uncomment to set the SDK log level programmatically. Or specify
+    // branch_log_level in the Info.plist.
+    // BNCLogSetDisplayLevel(BNCLogLevelAll);
 
     // Set Branch.useTestBranchKey = YES; to have Branch use the test key that's in the app's
     // Info.plist file. This makes Branch test against your test environment (As shown in the Branch

--- a/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
+++ b/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
@@ -61,5 +61,7 @@
 		<key>test</key>
 		<string>key_test_jkptOCZtmtxhOMZ11ynbXecdDCd93cbr</string>
 	</dict>
+	<key>branch_log_level</key>
+	<string>debug</string>
 </dict>
 </plist>


### PR DESCRIPTION
- Changed the default log level depending on the DEBUG flag. In Debug builds, defaults to BNCLogLevelDebug. In Release builds, defaults to BNCLogLevelNone.
- Added BNCLog.h to Branch.h to expose BNCLogSetDisplayLevel().
- Added support for `branch_log_level` in the Info.plist.