### PR TITLE
INTENG-3582 Fix to show dynamic links on Swift-Testbed

### DIFF
--- a/Branch-TestBed-Swift/TestBed-Swift/ViewController.swift
+++ b/Branch-TestBed-Swift/TestBed-Swift/ViewController.swift
@@ -385,7 +385,7 @@ class ViewController: UITableViewController, BranchShareLinkDelegate {
         }
         
         branchUniversalObject.getShortUrl(with: branchLinkProperties) { (url, error) in
-            if (error == nil) {
+            if (url != nil) {
                 print(self.branchLinkProperties.description())
                 print(self.branchUniversalObject.description())
                 print("Link Created: \(String(describing: url?.description))")


### PR DESCRIPTION
Checking if the link URL returned is nil instead of checking for error. The Branch SDK throws network connectivity error along with the Dynamic link when trying to create a link with the internet connectivity down.