### PR TITLE
Add session data guard (GitHub Issue #672).

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCLog.m
+++ b/Branch-SDK/Branch-SDK/BNCLog.m
@@ -608,11 +608,10 @@ void BNCLogWriteMessageFormat(
         @"[branch.io] %@(%d) %@: %@", filename, lineNumber, levelString, m];
     va_end(args);
 
-    if (logLevel >= bnc_LogDisplayLevel) {
-        NSLog(@"%@", s); // Upgrade this to unified logging when we can.
-    }
-
     dispatch_async(bnc_LogQueue, ^{
+        if (logLevel >= bnc_LogDisplayLevel) {
+            NSLog(@"%@", s); // Upgrade this to unified logging when we can.
+        }
         if (bnc_LoggingFunction)
             bnc_LoggingFunction([NSDate date], logLevel, s);
     });

--- a/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
@@ -109,6 +109,29 @@
     [BNCSystemObserver setUpdateState];
 
     NSString *sessionData = data[BRANCH_RESPONSE_KEY_SESSION_DATA];
+    if (sessionData == nil || [sessionData isKindOfClass:[NSString class]]) {
+    } else
+    if (([sessionData isKindOfClass:[NSDictionary class]] ||
+         [sessionData isKindOfClass:[NSArray class]]) &&
+            [NSJSONSerialization isValidJSONObject:sessionData]) {
+        BNCLogWarning(@"Received session data of type '%@'.", NSStringFromClass(sessionData.class));
+        @try {
+            NSError *error = nil;
+            NSData* data = [NSJSONSerialization dataWithJSONObject:sessionData options:0 error:&error];
+            if (error || data == nil) {
+                BNCLogError(@"Error converting JSON: %@.", error);
+                sessionData = nil;
+            } else {
+                sessionData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            }
+        }
+        @catch (id) {
+            sessionData = nil;
+        }
+    } else {
+        BNCLogError(@"Received session data of type '%@'.", NSStringFromClass(sessionData.class));
+        sessionData = nil;
+    }
 
     // Update session params
     preferenceHelper.sessionParams = sessionData;

--- a/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
@@ -112,14 +112,17 @@
     if (sessionData == nil || [sessionData isKindOfClass:[NSString class]]) {
     } else
     if ([sessionData isKindOfClass:[NSDictionary class]]) {
-        BNCLogWarning(@"Received session data of type '%@'.", NSStringFromClass(sessionData.class));
+        BNCLogWarning(@"Received session data of type '%@' data is '%@'.",
+            NSStringFromClass(sessionData.class), sessionData);
         sessionData = [BNCEncodingUtils encodeDictionaryToJsonString:(NSDictionary*)sessionData];
     } else
     if ([sessionData isKindOfClass:[NSArray class]]) {
-        BNCLogWarning(@"Received session data of type '%@'.", NSStringFromClass(sessionData.class));
+        BNCLogWarning(@"Received session data of type '%@' data is '%@'.",
+            NSStringFromClass(sessionData.class), sessionData);
         sessionData = [BNCEncodingUtils encodeArrayToJsonString:(NSArray*)sessionData];
     } else {
-        BNCLogError(@"Received session data of type '%@'.", NSStringFromClass(sessionData.class));
+        BNCLogError(@"Received session data of type '%@' data is '%@'.",
+            NSStringFromClass(sessionData.class), sessionData);
         sessionData = nil;
     }
 

--- a/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchOpenRequest.m
@@ -111,23 +111,13 @@
     NSString *sessionData = data[BRANCH_RESPONSE_KEY_SESSION_DATA];
     if (sessionData == nil || [sessionData isKindOfClass:[NSString class]]) {
     } else
-    if (([sessionData isKindOfClass:[NSDictionary class]] ||
-         [sessionData isKindOfClass:[NSArray class]]) &&
-            [NSJSONSerialization isValidJSONObject:sessionData]) {
+    if ([sessionData isKindOfClass:[NSDictionary class]]) {
         BNCLogWarning(@"Received session data of type '%@'.", NSStringFromClass(sessionData.class));
-        @try {
-            NSError *error = nil;
-            NSData* data = [NSJSONSerialization dataWithJSONObject:sessionData options:0 error:&error];
-            if (error || data == nil) {
-                BNCLogError(@"Error converting JSON: %@.", error);
-                sessionData = nil;
-            } else {
-                sessionData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            }
-        }
-        @catch (id) {
-            sessionData = nil;
-        }
+        sessionData = [BNCEncodingUtils encodeDictionaryToJsonString:(NSDictionary*)sessionData];
+    } else
+    if ([sessionData isKindOfClass:[NSArray class]]) {
+        BNCLogWarning(@"Received session data of type '%@'.", NSStringFromClass(sessionData.class));
+        sessionData = [BNCEncodingUtils encodeArrayToJsonString:(NSArray*)sessionData];
     } else {
         BNCLogError(@"Received session data of type '%@'.", NSStringFromClass(sessionData.class));
         sessionData = nil;


### PR DESCRIPTION
Added a guard for session data. Sometimes the session data is not stringified (an error on the backend) but this guards against a crash in the SDK.


