### PR TITLE
Initialization would lock up sometimes in iOS 8.

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -805,7 +805,7 @@ NSURL* _Null_unspecified BNCCreateDirectoryForBranchURLWithPath(NSSearchPathDire
 
     for (NSURL *URL in URLs) {
         NSError *error = nil;
-        NSURL *branchURL = [URL URLByAppendingPathComponent:@"io.branch" isDirectory:YES];
+        NSURL *branchURL = [[NSURL alloc] initWithString:@"io.branch" relativeToURL:URL];
         BOOL success =
             [fileManager
                 createDirectoryAtURL:branchURL

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -131,9 +131,9 @@ static NSURL* bnc_logURL = nil;
     @synchronized (self) {
         if (!bnc_logURL) {
             BNCLogInitialize();
-            BNCLogSetDisplayLevel(BNCLogLevelAll);    
+            BNCLogSetDisplayLevel(BNCLogLevelAll);
             bnc_logURL = BNCURLForBranchDirectory();
-            bnc_logURL = [bnc_logURL URLByAppendingPathComponent:@"Branch.log"];
+            bnc_logURL = [[NSURL alloc] initWithString:@"Branch.log" relativeToURL:bnc_logURL];
             BNCLogSetOutputToURLByteWrap(bnc_logURL, 102400);
             BNCLogSetDisplayLevel(BNCLogLevelWarning);
             BNCLogDebug(@"Branch version %@ started at %@.", BNC_SDK_VERSION, [NSDate date]);

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 Branch iOS SDK Change Log
 
+- v0.17.10
+  * _*Master Release*_ - August 23, 2017
+  * Don't do cookie based matching in iOS 11 (AIS-307, GH-#681).
+  * Fix an initialization problem in iOS 8.
+    Logging was calling a protocol method which would lock up initialization on iOS 8 (GH-#694).
+
 - v0.17.9
   * _*Master Release*_ - August 15, 2017
   * Fixed the Branch.framework static library build. How long was this broken? A year? Since 12.2?


### PR DESCRIPTION
* Logging was calling a protocol method which would lock up initialization sometimes on iOS 8.
* Updated ChangeLog.md.
* Tested on iOS 8 and Xcode 7 and higher.

