### PR TITLE
Send the Apple Search Ad attribution only when it changes (DLA-969).

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -39,6 +39,7 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 @property (strong, nonatomic) NSMutableDictionary *savedAnalyticsData;
 @property (assign, nonatomic) NSInteger installRequestDelay;
 @property (strong, nonatomic) NSDictionary *appleSearchAdDetails;
+@property (assign, nonatomic) BOOL          appleSearchAdNeedsSend;
 @property (strong, nonatomic) NSString *lastSystemBuildVersion;
 @property (strong, nonatomic) NSString *browserUserAgentString;
 @property (strong, atomic) NSString *branchAPIURL;

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -121,24 +121,6 @@ NSString * const BRANCH_PREFS_KEY_ANALYTICS_MANIFEST = @"bnc_branch_analytics_ma
     return preferenceHelper;
 }
 
-
-/*
-
-    This creates one global queue.  Not so desirable.
-
-- (NSOperationQueue *)persistPrefsQueue {
-    static NSOperationQueue *persistPrefsQueue;
-    static dispatch_once_t persistOnceToken;
-    
-    dispatch_once(&persistOnceToken, ^{
-        persistPrefsQueue = [[NSOperationQueue alloc] init];
-        persistPrefsQueue.maxConcurrentOperationCount = 1;
-    });
-
-    return persistPrefsQueue;
-}
-*/
-
 - (NSOperationQueue *)persistPrefsQueue {
     @synchronized (self) {
         if (_persistPrefsQueue)
@@ -419,6 +401,14 @@ NSString * const BRANCH_PREFS_KEY_ANALYTICS_MANIFEST = @"bnc_branch_analytics_ma
         _appleSearchAdDetails = (NSDictionary *) [self readObjectFromDefaults:BRANCH_PREFS_KEY_APPLE_SEARCH_ADS_INFO];
     }
     return [_appleSearchAdDetails isKindOfClass:[NSDictionary class]] ? _appleSearchAdDetails : nil;
+}
+
+- (void) setAppleSearchAdNeedsSend:(BOOL)appleSearchAdNeedsSend {
+    [self writeBoolToDefaults:@"_appleSearchAdNeedsSend" value:appleSearchAdNeedsSend];
+}
+
+- (BOOL) appleSearchAdNeedsSend {
+    return [self readBoolFromDefaults:@"_appleSearchAdNeedsSend"];
 }
 
 - (NSString*) lastSystemBuildVersion {

--- a/Branch-SDK/Branch-SDK/Networking/Requests/BranchInstallRequest.m
+++ b/Branch-SDK/Branch-SDK/Networking/Requests/BranchInstallRequest.m
@@ -38,7 +38,7 @@
 
     params[BRANCH_REQUEST_KEY_DEBUG] = @(preferenceHelper.isDebug);
 
-    if (preferenceHelper.appleSearchAdDetails) {
+    if (preferenceHelper.appleSearchAdNeedsSend) {
         NSString *encodedSearchData = nil;
         @try {
             NSData *jsonData = [BNCEncodingUtils encodeDictionaryToJsonData:preferenceHelper.appleSearchAdDetails];

--- a/Branch-SDK/Branch-SDK/Networking/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Networking/Requests/BranchOpenRequest.m
@@ -57,8 +57,10 @@
     [self safeSetValue:[BNCSystemObserver getAppVersion] forKey:BRANCH_REQUEST_KEY_APP_VERSION onDict:params];
     [self safeSetValue:[BNCSystemObserver getDefaultUriScheme] forKey:BRANCH_REQUEST_KEY_URI_SCHEME onDict:params];
     [self safeSetValue:[BNCSystemObserver getUpdateState] forKey:BRANCH_REQUEST_KEY_UPDATE onDict:params];
-    [self safeSetValue:[NSNumber numberWithBool:preferenceHelper.checkedFacebookAppLinks] forKey:BRANCH_REQUEST_KEY_CHECKED_FACEBOOK_APPLINKS onDict:params];
-    [self safeSetValue:[NSNumber numberWithBool:preferenceHelper.checkedAppleSearchAdAttribution] forKey:BRANCH_REQUEST_KEY_CHECKED_APPLE_AD_ATTRIBUTION onDict:params];
+    [self safeSetValue:[NSNumber numberWithBool:preferenceHelper.checkedFacebookAppLinks]
+        forKey:BRANCH_REQUEST_KEY_CHECKED_FACEBOOK_APPLINKS onDict:params];
+    [self safeSetValue:[NSNumber numberWithBool:preferenceHelper.checkedAppleSearchAdAttribution]
+        forKey:BRANCH_REQUEST_KEY_CHECKED_APPLE_AD_ATTRIBUTION onDict:params];
     [self safeSetValue:preferenceHelper.linkClickIdentifier forKey:BRANCH_REQUEST_KEY_LINK_IDENTIFIER onDict:params];
     [self safeSetValue:preferenceHelper.spotlightIdentifier forKey:BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER onDict:params];
     [self safeSetValue:preferenceHelper.universalLinkUrl forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:params];
@@ -70,7 +72,7 @@
     [cdDict bnc_safeSetObject:[BNCSystemObserver getBundleID] forKey:BRANCH_BUNDLE_IDENTIFIER];
     [self safeSetValue:cdDict forKey:BRANCH_CONTENT_DISCOVER_KEY onDict:params];
 
-    if (preferenceHelper.appleSearchAdDetails) {
+    if (preferenceHelper.appleSearchAdNeedsSend) {
         NSString *encodedSearchData = nil;
         @try {
             NSData *jsonData = [BNCEncodingUtils encodeDictionaryToJsonData:preferenceHelper.appleSearchAdDetails];
@@ -80,7 +82,6 @@
                     forKey:BRANCH_REQUEST_KEY_SEARCH_AD
                     onDict:params];
     }
-    /**/
 
     [serverInterface postRequest:params url:[preferenceHelper getAPIURL:BRANCH_REQUEST_ENDPOINT_OPEN] key:key callback:callback];
 }
@@ -186,7 +187,7 @@
     preferenceHelper.spotlightIdentifier = nil;
     preferenceHelper.universalLinkUrl = nil;
     preferenceHelper.externalIntentURI = nil;
-    preferenceHelper.appleSearchAdDetails = nil;
+    preferenceHelper.appleSearchAdNeedsSend = NO;
 
     if (data[BRANCH_RESPONSE_KEY_BRANCH_IDENTITY]) {
         preferenceHelper.identityID = data[BRANCH_RESPONSE_KEY_BRANCH_IDENTITY];


### PR DESCRIPTION
* Send the Apple Search Ad attribution only when it changes.
* Removed some code that has been commented out for a while.

