### PR TITLE
View controller manager

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCViewControllerManager.h
+++ b/Branch-SDK/Branch-SDK/BNCViewControllerManager.h
@@ -1,0 +1,31 @@
+//
+//  BNCViewControllerManager.h
+//  Branch
+//
+//  Created by Jimmy Dee on 10/30/17.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ * Utility class to find the current view controller for use with presentViewController:animated:completion:.
+ */
+@interface BNCViewControllerManager : NSObject
+
+/**
+ * The current view controller to use.
+ *
+ * This can be nil in an extension, when UIApplication is not defined, if UIApplication.sharedApplication.keyWindow is nil
+ * or if the current view controller does not respond to presentViewController:animated:completion:.
+ */
+@property (readonly, nullable, nonatomic) UIViewController *currentViewController;
+
+/**
+ * Convenience method to present a view controller from the currentViewController.
+ * @param viewControllerToPresent an instance of UIViewController to present
+ * @param flag whether the presentation should be animated
+ * @param completion an optional completion block called once the presentation is complete
+ */
+- (void)presentViewController:(UIViewController * _Nonnull)viewControllerToPresent animated: (BOOL)flag completion:(void (^ __nullable)(void))completion;
+
+@end

--- a/Branch-SDK/Branch-SDK/BNCViewControllerManager.h
+++ b/Branch-SDK/Branch-SDK/BNCViewControllerManager.h
@@ -5,7 +5,7 @@
 //  Created by Jimmy Dee on 10/30/17.
 //
 
-#import <Foundation/Foundation.h>
+@import UIKit;
 
 /**
  * Utility class to find the current view controller for use with presentViewController:animated:completion:.

--- a/Branch-SDK/Branch-SDK/BNCViewControllerManager.m
+++ b/Branch-SDK/Branch-SDK/BNCViewControllerManager.m
@@ -13,8 +13,9 @@
     Class UIApplicationClass = NSClassFromString(@"UIApplication");
     UIViewController *current = [[[UIApplicationClass sharedApplication] keyWindow] rootViewController];
 
-    if (@available(iOS 8.0, *)) {
-        while (current.presentedViewController && ![current.presentedViewController isKindOfClass:UIAlertController.class]) {
+    Class UIAlertControllerClass = NSClassFromString(@"UIAlertController");
+    if (UIAlertControllerClass) {
+        while (current.presentedViewController && ![current.presentedViewController isKindOfClass:UIAlertControllerClass]) {
             current = current.presentedViewController;
         }
     } else {

--- a/Branch-SDK/Branch-SDK/BNCViewControllerManager.m
+++ b/Branch-SDK/Branch-SDK/BNCViewControllerManager.m
@@ -1,0 +1,31 @@
+//
+//  BNCViewControllerManager.m
+//  Branch
+//
+//  Created by Jimmy Dee on 10/30/17.
+//
+
+#import "BNCViewControllerManager.h"
+
+@implementation BNCViewControllerManager
+
+- (UIViewController *)currentViewController {
+    Class UIApplicationClass = NSClassFromString(@"UIApplication");
+    UIViewController *current = [[[UIApplicationClass sharedApplication] keyWindow] rootViewController];
+
+    if (@available(iOS 8.0, *)) {
+        while (current.presentedViewController && ![current.presentedViewController isKindOfClass:UIAlertController.class]) {
+            current = current.presentedViewController;
+        }
+    } else {
+        while (current.presentedViewController) current = current.presentedViewController;
+    }
+    if ([current respondsToSelector:@selector(presentViewController:animated:completion:)]) return current;
+    return nil;
+}
+
+- (void)presentViewController:(UIViewController *)viewControllerToPresent animated:(BOOL)flag completion:(void (^)(void))completion {
+    [self.currentViewController presentViewController:viewControllerToPresent animated:flag completion:completion];
+}
+
+@end

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -20,6 +20,7 @@
 #import "BNCServerResponse.h"
 #import "BNCStrongMatchHelper.h"
 #import "BNCSystemObserver.h"
+#import "BNCViewControllerManager.h"
 #import "BranchCloseRequest.h"
 #import "BranchConstants.h"
 #import "BranchContentDiscoverer.h"
@@ -1924,7 +1925,7 @@ void BNCPerformBlockOnMainThread(dispatch_block_t block) {
                 BNCLogWarning(@"The automatic deeplink view controller '%@' for key '%@' does not implement 'configureControlWithData:'.",
                     branchSharingController, key);
             }
-            self.deepLinkPresentingController = [[[UIApplicationClass sharedApplication].delegate window] rootViewController];
+            self.deepLinkPresentingController = [[BNCViewControllerManager alloc] init].currentViewController;
 
             if([self.deepLinkControllers[key] isKindOfClass:[BNCDeepLinkViewControllerInstance class]]) {
                 BNCDeepLinkViewControllerInstance* deepLinkInstance = self.deepLinkControllers[key];

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1906,7 +1906,6 @@ void BNCPerformBlockOnMainThread(dispatch_block_t block) {
         }
     }
 
-    Class UIApplicationClass = NSClassFromString(@"UIApplication");
     if (self.shouldAutomaticallyDeepLink) {
         // Find any matched keys, then launch any controllers that match
         // TODO which one to launch if more than one match?

--- a/Branch-SDK/Branch-SDK/BranchShareLink.m
+++ b/Branch-SDK/Branch-SDK/BranchShareLink.m
@@ -13,6 +13,7 @@
 #import "BNCDeviceInfo.h"
 #import "BNCXcode7Support.h"
 #import "BNCLog.h"
+#import "BNCViewControllerManager.h"
 #import "Branch.h"
 @class BranchShareActivityItem;
 
@@ -197,11 +198,7 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
     if ([viewController respondsToSelector:@selector(presentViewController:animated:completion:)]) {
         presentingViewController = viewController;
     } else {
-        Class UIApplicationClass = NSClassFromString(@"UIApplication");
-        UIViewController *rootController = [UIApplicationClass sharedApplication].delegate.window.rootViewController;
-        if ([rootController respondsToSelector:@selector(presentViewController:animated:completion:)]) {
-            presentingViewController = rootController;
-        }
+        presentingViewController = [[BNCViewControllerManager alloc] init].currentViewController;
     }
 
     if (!presentingViewController) {

--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.m
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.m
@@ -14,6 +14,7 @@
 #import "BNCLog.h"
 #import "BNCLocalization.h"
 #import "BNCEncodingUtils.h"
+#import "BNCViewControllerManager.h"
 #import "Branch.h"
 
 #pragma mark BranchContentSchema
@@ -482,11 +483,7 @@ BranchCondition _Nonnull BranchConditionRefurbished   = @"REFURBISHED";
         presentingViewController = viewController;
     }
     else {
-        Class UIApplicationClass = NSClassFromString(@"UIApplication");
-        if ([[[[UIApplicationClass sharedApplication].delegate window] rootViewController]
-               respondsToSelector:@selector(presentViewController:animated:completion:)]) {
-            presentingViewController = [[[UIApplicationClass sharedApplication].delegate window] rootViewController];
-        }
+        presentingViewController = [[BNCViewControllerManager alloc] init].currentViewController;
     }
     
     if (linkProperties.controlParams[BRANCH_LINK_DATA_KEY_EMAIL_SUBJECT]) {

--- a/Branch-SDK/Branch-SDK/BranchViewHandler.m
+++ b/Branch-SDK/Branch-SDK/BranchViewHandler.m
@@ -11,6 +11,7 @@
 #import "BranchViewHandler.h"
 #import "Branch.h"
 #import "BranchView.h"
+#import "BNCViewControllerManager.h"
 
 @interface BranchViewHandler() <UIWebViewDelegate>
 
@@ -116,8 +117,7 @@ static NSString *currentBranchViewID;
         if (self.pendingBranchView != nil && self.pendingWebview != nil) {
             UIViewController *holderView = [[UIViewController alloc] init];
             [holderView.view insertSubview:self.pendingWebview atIndex:0];
-            Class UIApplicationClass = NSClassFromString(@"UIApplication");
-            UIViewController *presentingViewController = [[[[UIApplicationClass sharedApplication] windows] firstObject] rootViewController];
+            UIViewController *presentingViewController = [[BNCViewControllerManager alloc] init].currentViewController;
             [presentingViewController presentViewController:holderView animated:YES completion:nil];
             
             [self.pendingBranchView updateUsageCount];

--- a/Branch-TestBed-Swift/TestBed-Swift.xcodeproj/project.pbxproj
+++ b/Branch-TestBed-Swift/TestBed-Swift.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		63F8BB201D57D2BE0013B6F7 /* LinkPropertiesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8BB1F1D57D2BE0013B6F7 /* LinkPropertiesTableViewController.swift */; };
 		63F8BB241D57E7730013B6F7 /* ArrayTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8BB231D57E7730013B6F7 /* ArrayTableViewController.swift */; };
 		7B18DF4D1F1F016600C25C84 /* BNCCrashlyticsWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B18DF4C1F1F016600C25C84 /* BNCCrashlyticsWrapper.m */; };
+		7BC1582E1FA79B7500404895 /* BNCViewControllerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC1582D1FA79B7500404895 /* BNCViewControllerManager.m */; };
 		F155BFF21EF37EEA00BF4566 /* BNCDeepLinkViewControllerInstance.m in Sources */ = {isa = PBXBuildFile; fileRef = F155BFF11EF37EEA00BF4566 /* BNCDeepLinkViewControllerInstance.m */; };
 /* End PBXBuildFile section */
 
@@ -313,6 +314,8 @@
 		63F8BB231D57E7730013B6F7 /* ArrayTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayTableViewController.swift; sourceTree = "<group>"; };
 		7B18DF4B1F1F016600C25C84 /* BNCCrashlyticsWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCCrashlyticsWrapper.h; sourceTree = "<group>"; };
 		7B18DF4C1F1F016600C25C84 /* BNCCrashlyticsWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCCrashlyticsWrapper.m; sourceTree = "<group>"; };
+		7BC1582C1FA79B7400404895 /* BNCViewControllerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCViewControllerManager.h; sourceTree = "<group>"; };
+		7BC1582D1FA79B7500404895 /* BNCViewControllerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCViewControllerManager.m; sourceTree = "<group>"; };
 		8225BB463EBCEBED0D965277 /* libPods-TestBed-Swift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestBed-Swift.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE2BDDFD78122922968E1EC7 /* Pods-TestBed-Swift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestBed-Swift.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestBed-Swift/Pods-TestBed-Swift.release.xcconfig"; sourceTree = "<group>"; };
 		F155BFED1EF37EDB00BF4566 /* BNCLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCLog.h; sourceTree = "<group>"; };
@@ -453,6 +456,8 @@
 				4D4F27FA1E400F9800282A34 /* BNCStrongMatchHelper.m */,
 				4D4F27FB1E400F9800282A34 /* BNCSystemObserver.h */,
 				4D4F27FC1E400F9800282A34 /* BNCSystemObserver.m */,
+				7BC1582C1FA79B7400404895 /* BNCViewControllerManager.h */,
+				7BC1582D1FA79B7500404895 /* BNCViewControllerManager.m */,
 				4D4F27FD1E400F9800282A34 /* BNCXcode7Support.h */,
 				4D4F27FE1E400F9800282A34 /* BNCXcode7Support.m */,
 				4D4F27FF1E400F9800282A34 /* Branch-SDK-Prefix.pch */,
@@ -1065,6 +1070,7 @@
 				639D53CB1F7014E700C90435 /* IntegratedSDKsData.swift in Sources */,
 				4D351A101F0D6362004BD4AA /* BNCLog.m in Sources */,
 				4D4F284E1E400F9800282A34 /* Branch.m in Sources */,
+				7BC1582E1FA79B7500404895 /* BNCViewControllerManager.m in Sources */,
 				63AAF0FD1CF7F4AD00CA98BD /* CreditHistoryViewController.swift in Sources */,
 				63A849381F76BAFC007705C8 /* TableFormViewController.swift in Sources */,
 				4D4F28471E400F9800282A34 /* BNCPreferenceHelper.m in Sources */,

--- a/Branch-TestBed-Xcode-7/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed-Xcode-7/Branch-TestBed.xcodeproj/project.pbxproj
@@ -151,6 +151,8 @@
 		67486B8E1B93B48A0044D872 /* BNCStrongMatchHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 67486B8C1B93B48A0044D872 /* BNCStrongMatchHelper.m */; };
 		677F4CB51C1FB1910029F2B3 /* Branch-TestBed.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 677F4CB41C1FB0FA0029F2B3 /* Branch-TestBed.entitlements */; };
 		67F270891BA9FCFF002546A7 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		7B75D5CB1FA79C6100BD691C /* BNCViewControllerManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B75D5C91FA79C6100BD691C /* BNCViewControllerManager.h */; };
+		7B75D5CC1FA79C6100BD691C /* BNCViewControllerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B75D5CA1FA79C6100BD691C /* BNCViewControllerManager.m */; };
 		7D0C97191D8753C9004E14B1 /* BranchContentDiscoverer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C97181D8753C9004E14B1 /* BranchContentDiscoverer.m */; };
 		7D0C971D1D875465004E14B1 /* BranchContentDiscoveryManifest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C971C1D875465004E14B1 /* BranchContentDiscoveryManifest.m */; };
 		7D0C97201D87549B004E14B1 /* BranchContentPathProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C971F1D87549B004E14B1 /* BranchContentPathProperties.m */; };
@@ -332,6 +334,8 @@
 		67BBCF271A69E49A009C7DAE /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSpotlight.framework; path = System/Library/Frameworks/CoreSpotlight.framework; sourceTree = SDKROOT; };
 		69347EDA2E4ED874ED5DA0B3 /* Pods-Branch-SDK-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Branch-SDK-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Branch-SDK-Tests/Pods-Branch-SDK-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		7B75D5C91FA79C6100BD691C /* BNCViewControllerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCViewControllerManager.h; sourceTree = "<group>"; };
+		7B75D5CA1FA79C6100BD691C /* BNCViewControllerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCViewControllerManager.m; sourceTree = "<group>"; };
 		7D0C97181D8753C9004E14B1 /* BranchContentDiscoverer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchContentDiscoverer.m; sourceTree = "<group>"; };
 		7D0C971A1D8753EA004E14B1 /* BranchContentDiscoverer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoverer.h; sourceTree = "<group>"; };
 		7D0C971B1D875445004E14B1 /* BranchContentDiscoveryManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoveryManifest.h; sourceTree = "<group>"; };
@@ -591,6 +595,8 @@
 				67486B8C1B93B48A0044D872 /* BNCStrongMatchHelper.m */,
 				670016C71946309100A9E103 /* BNCSystemObserver.h */,
 				670016C81946309100A9E103 /* BNCSystemObserver.m */,
+				7B75D5C91FA79C6100BD691C /* BNCViewControllerManager.h */,
+				7B75D5CA1FA79C6100BD691C /* BNCViewControllerManager.m */,
 				4D8999EA1DC108FF00F7EE0A /* BNCXcode7Support.h */,
 				4D8999EB1DC108FF00F7EE0A /* BNCXcode7Support.m */,
 				670016BD1946309100A9E103 /* Branch.h */,
@@ -712,6 +718,7 @@
 				4D44E7C91E68F34E00793D79 /* BNCDebug.h in Headers */,
 				466B587A1B17780A00A69EDE /* BNCError.h in Headers */,
 				466B587D1B17780A00A69EDE /* BNCLinkCache.h in Headers */,
+				7B75D5CB1FA79C6100BD691C /* BNCViewControllerManager.h in Headers */,
 				466B587C1B17780A00A69EDE /* BNCLinkData.h in Headers */,
 				4D44E7CB1E68F34E00793D79 /* BNCLog.h in Headers */,
 				4D9921141EE208B400A4AB92 /* BNCNetworkServiceProtocol.h in Headers */,
@@ -961,6 +968,7 @@
 				4D8EE7A61E1F0A5D00B1F450 /* BNCCommerceEvent.m in Sources */,
 				2BD7C4601F27D7AB003696AF /* BNCDeepLinkViewControllerInstance.m in Sources */,
 				7D4DAC251C8FA908008E37DB /* BranchViewHandler.m in Sources */,
+				7B75D5CC1FA79C6100BD691C /* BNCViewControllerManager.m in Sources */,
 				4D9921321EE208B400A4AB92 /* BranchShortUrlSyncRequest.m in Sources */,
 				466B58591B17779C00A69EDE /* BNCPreferenceHelper.m in Sources */,
 				4D9921201EE208B400A4AB92 /* BranchCreditHistoryRequest.m in Sources */,

--- a/Branch-TestBed-iMessage/Branch-TestBed-iMessage.xcodeproj/project.pbxproj
+++ b/Branch-TestBed-iMessage/Branch-TestBed-iMessage.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		67E91FCC1D769FE30039F1C4 /* BranchView.m in Sources */ = {isa = PBXBuildFile; fileRef = 67E91F911D769FE30039F1C4 /* BranchView.m */; };
 		67E91FCD1D769FE30039F1C4 /* BranchViewHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 67E91F931D769FE30039F1C4 /* BranchViewHandler.m */; };
 		7B18DF501F1F028600C25C84 /* BNCCrashlyticsWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B18DF4F1F1F028600C25C84 /* BNCCrashlyticsWrapper.m */; };
+		7BC158271FA79A4B00404895 /* BNCViewControllerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC158261FA79A4B00404895 /* BNCViewControllerManager.m */; };
+		7BC1582A1FA79A6F00404895 /* BranchEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC158291FA79A6F00404895 /* BranchEvent.m */; };
 		E212CC5E1D9DE6A900603475 /* BranchContentDiscoveryManifest.m in Sources */ = {isa = PBXBuildFile; fileRef = E212CC5D1D9DE6A900603475 /* BranchContentDiscoveryManifest.m */; };
 		E212CC611D9DE6C400603475 /* BranchContentPathProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = E212CC601D9DE6C400603475 /* BranchContentPathProperties.m */; };
 		E212CC641D9DE6D800603475 /* BranchContentDiscoverer.m in Sources */ = {isa = PBXBuildFile; fileRef = E212CC631D9DE6D800603475 /* BranchContentDiscoverer.m */; };
@@ -204,6 +206,11 @@
 		67E91FB81D769FE30039F1C4 /* Fabric.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
 		7B18DF4E1F1F028600C25C84 /* BNCCrashlyticsWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCCrashlyticsWrapper.h; sourceTree = "<group>"; };
 		7B18DF4F1F1F028600C25C84 /* BNCCrashlyticsWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCCrashlyticsWrapper.m; sourceTree = "<group>"; };
+		7BC158251FA79A4A00404895 /* BNCViewControllerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCViewControllerManager.h; sourceTree = "<group>"; };
+		7BC158261FA79A4B00404895 /* BNCViewControllerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCViewControllerManager.m; sourceTree = "<group>"; };
+		7BC158281FA79A6F00404895 /* BranchEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchEvent.h; sourceTree = "<group>"; };
+		7BC158291FA79A6F00404895 /* BranchEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchEvent.m; sourceTree = "<group>"; };
+		7BC1582B1FA79A7B00404895 /* BNCFieldDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCFieldDefines.h; sourceTree = "<group>"; };
 		E212CC5C1D9DE6A900603475 /* BranchContentDiscoveryManifest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoveryManifest.h; sourceTree = "<group>"; };
 		E212CC5D1D9DE6A900603475 /* BranchContentDiscoveryManifest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchContentDiscoveryManifest.m; sourceTree = "<group>"; };
 		E212CC5F1D9DE6C400603475 /* BranchContentPathProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchContentPathProperties.h; sourceTree = "<group>"; };
@@ -359,6 +366,7 @@
 				67E91F6F1D769FE30039F1C4 /* BNCError.m */,
 				67E91F701D769FE30039F1C4 /* BNCFabricAnswers.h */,
 				67E91F711D769FE30039F1C4 /* BNCFabricAnswers.m */,
+				7BC1582B1FA79A7B00404895 /* BNCFieldDefines.h */,
 				67E91F721D769FE30039F1C4 /* BNCLinkCache.h */,
 				67E91F731D769FE30039F1C4 /* BNCLinkCache.m */,
 				67E91F741D769FE30039F1C4 /* BNCLinkData.h */,
@@ -373,6 +381,8 @@
 				67E91F7F1D769FE30039F1C4 /* BNCStrongMatchHelper.m */,
 				67E91F801D769FE30039F1C4 /* BNCSystemObserver.h */,
 				67E91F811D769FE30039F1C4 /* BNCSystemObserver.m */,
+				7BC158251FA79A4A00404895 /* BNCViewControllerManager.h */,
+				7BC158261FA79A4B00404895 /* BNCViewControllerManager.m */,
 				4DB47D501F042BB900C53C29 /* BNCXcode7Support.h */,
 				4DB47D511F042BB900C53C29 /* BNCXcode7Support.m */,
 				67E91F821D769FE30039F1C4 /* Branch-SDK-Prefix.pch */,
@@ -391,6 +401,8 @@
 				67E91F891D769FE30039F1C4 /* BranchCSSearchableItemAttributeSet.h */,
 				67E91F8A1D769FE30039F1C4 /* BranchCSSearchableItemAttributeSet.m */,
 				67E91F8B1D769FE30039F1C4 /* BranchDeepLinkingController.h */,
+				7BC158281FA79A6F00404895 /* BranchEvent.h */,
+				7BC158291FA79A6F00404895 /* BranchEvent.m */,
 				67E91F8C1D769FE30039F1C4 /* BranchLinkProperties.h */,
 				67E91F8D1D769FE30039F1C4 /* BranchLinkProperties.m */,
 				4DB567351E79FD5E00A8A324 /* BranchShareLink.h */,
@@ -530,6 +542,7 @@
 				67E91FC01D769FE30039F1C4 /* BNCPreferenceHelper.m in Sources */,
 				67E91FBB1D769FE30039F1C4 /* BNCEncodingUtils.m in Sources */,
 				67E91FBC1D769FE30039F1C4 /* BNCError.m in Sources */,
+				7BC1582A1FA79A6F00404895 /* BranchEvent.m in Sources */,
 				67E91FB91D769FE30039F1C4 /* BNCContentDiscoveryManager.m in Sources */,
 				67E91FC81D769FE30039F1C4 /* BranchConstants.m in Sources */,
 				67E91FBF1D769FE30039F1C4 /* BNCLinkData.m in Sources */,
@@ -539,6 +552,7 @@
 				67E91FC41D769FE30039F1C4 /* BNCStrongMatchHelper.m in Sources */,
 				4D6A275B1F29557200027264 /* BNCLocalization.m in Sources */,
 				2BD7C40E1F27D4E3003696AF /* BNCNetworkService.m in Sources */,
+				7BC158271FA79A4B00404895 /* BNCViewControllerManager.m in Sources */,
 				7B18DF501F1F028600C25C84 /* BNCCrashlyticsWrapper.m in Sources */,
 				4DB567371E79FD5E00A8A324 /* BranchShareLink.m in Sources */,
 				4D698FF21E04B566006DA451 /* BNCConfig.m in Sources */,

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -157,6 +157,8 @@
 		7B18DF491F1F00E200C25C84 /* BNCCrashlyticsWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B18DF471F1F00E200C25C84 /* BNCCrashlyticsWrapper.h */; };
 		7B18DF4A1F1F00E200C25C84 /* BNCCrashlyticsWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B18DF481F1F00E200C25C84 /* BNCCrashlyticsWrapper.m */; };
 		7B18DF521F1F049F00C25C84 /* BNCCrashlyticsWrapper.Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B18DF511F1F049F00C25C84 /* BNCCrashlyticsWrapper.Test.m */; };
+		7BC158231FA799DF00404895 /* BNCViewControllerManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC158211FA799DF00404895 /* BNCViewControllerManager.h */; };
+		7BC158241FA799DF00404895 /* BNCViewControllerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC158221FA799DF00404895 /* BNCViewControllerManager.m */; };
 		7D0C97191D8753C9004E14B1 /* BranchContentDiscoverer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C97181D8753C9004E14B1 /* BranchContentDiscoverer.m */; };
 		7D0C971D1D875465004E14B1 /* BranchContentDiscoveryManifest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C971C1D875465004E14B1 /* BranchContentDiscoveryManifest.m */; };
 		7D0C97201D87549B004E14B1 /* BranchContentPathProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C971F1D87549B004E14B1 /* BranchContentPathProperties.m */; };
@@ -339,6 +341,8 @@
 		7B18DF471F1F00E200C25C84 /* BNCCrashlyticsWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCCrashlyticsWrapper.h; sourceTree = "<group>"; };
 		7B18DF481F1F00E200C25C84 /* BNCCrashlyticsWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCCrashlyticsWrapper.m; sourceTree = "<group>"; };
 		7B18DF511F1F049F00C25C84 /* BNCCrashlyticsWrapper.Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCCrashlyticsWrapper.Test.m; sourceTree = "<group>"; };
+		7BC158211FA799DF00404895 /* BNCViewControllerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCViewControllerManager.h; sourceTree = "<group>"; };
+		7BC158221FA799DF00404895 /* BNCViewControllerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCViewControllerManager.m; sourceTree = "<group>"; };
 		7D0C97181D8753C9004E14B1 /* BranchContentDiscoverer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchContentDiscoverer.m; sourceTree = "<group>"; };
 		7D0C971A1D8753EA004E14B1 /* BranchContentDiscoverer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoverer.h; sourceTree = "<group>"; };
 		7D0C971B1D875445004E14B1 /* BranchContentDiscoveryManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoveryManifest.h; sourceTree = "<group>"; };
@@ -612,6 +616,8 @@
 				67486B8C1B93B48A0044D872 /* BNCStrongMatchHelper.m */,
 				670016C71946309100A9E103 /* BNCSystemObserver.h */,
 				670016C81946309100A9E103 /* BNCSystemObserver.m */,
+				7BC158211FA799DF00404895 /* BNCViewControllerManager.h */,
+				7BC158221FA799DF00404895 /* BNCViewControllerManager.m */,
 				4D8999EA1DC108FF00F7EE0A /* BNCXcode7Support.h */,
 				4D8999EB1DC108FF00F7EE0A /* BNCXcode7Support.m */,
 				670016BD1946309100A9E103 /* Branch.h */,
@@ -785,6 +791,7 @@
 				4DCAC82B1F426F7C00405D1D /* BranchSetIdentityRequest.h in Headers */,
 				4DCAC82C1F426F7C00405D1D /* BranchShortUrlRequest.h in Headers */,
 				4DCAC82D1F426F7C00405D1D /* BranchShortUrlSyncRequest.h in Headers */,
+				7BC158231FA799DF00404895 /* BNCViewControllerManager.h in Headers */,
 				4DCAC82E1F426F7C00405D1D /* BranchSpotlightUrlRequest.h in Headers */,
 				4DCAC82F1F426F7C00405D1D /* BranchUserCompletedActionRequest.h in Headers */,
 				4DCAC8301F426F7C00405D1D /* NSMutableDictionary+Branch.h in Headers */,
@@ -1030,6 +1037,7 @@
 				4D130E7E1EE0C7B100A69A0A /* BranchCloseRequest.m in Sources */,
 				466B58591B17779C00A69EDE /* BNCPreferenceHelper.m in Sources */,
 				4D8999ED1DC108FF00F7EE0A /* BNCXcode7Support.m in Sources */,
+				7BC158241FA799DF00404895 /* BNCViewControllerManager.m in Sources */,
 				F1D359211ED4DCC500A93FD5 /* BNCDeepLinkViewControllerInstance.m in Sources */,
 				466B585F1B17779C00A69EDE /* BNCSystemObserver.m in Sources */,
 				4D130E941EE0C7B100A69A0A /* BranchSpotlightUrlRequest.m in Sources */,

--- a/Examples/WebViewExample/Podfile.lock
+++ b/Examples/WebViewExample/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Branch (0.20.2):
-    - Branch/Core (= 0.20.2)
-  - Branch/Core (0.20.2)
+  - Branch (0.21.0):
+    - Branch/Core (= 0.21.0)
+  - Branch/Core (0.21.0)
   - Cartography (2.1.0)
   - MBProgressHUD (1.0.0)
 
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  Branch: 307446a687231526f60eef0f12407ca4ed177c32
+  Branch: 5d459e0b4cbcf0d15e2b146b5b632dd7c0318f43
   Cartography: 19c2223a8dfed35d82b098d365213b7ceb25ab2b
   MBProgressHUD: 4890f671c94e8a0f3cf959aa731e9de2f036d71a
 

--- a/carthage-files/BranchSDK.xcodeproj/project.pbxproj
+++ b/carthage-files/BranchSDK.xcodeproj/project.pbxproj
@@ -63,10 +63,12 @@
 		4DAB17C11EE8A31B0079EEB4 /* BranchUserCompletedActionRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DAB17961EE8A31B0079EEB4 /* BranchUserCompletedActionRequest.m */; };
 		4DB5673A1E79FDAF00A8A324 /* BranchShareLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DB567381E79FDAF00A8A324 /* BranchShareLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DB5673B1E79FDAF00A8A324 /* BranchShareLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DB567391E79FDAF00A8A324 /* BranchShareLink.m */; };
-		4DCF4AFE1F43896F00AF9AAB /* BNCEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DCF4AFC1F43896F00AF9AAB /* BNCEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4DCF4AFF1F43896F00AF9AAB /* BNCEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DCF4AFD1F43896F00AF9AAB /* BNCEvent.m */; };
 		4DCF4B001F438A2B00AF9AAB /* BNCError.h in Headers */ = {isa = PBXBuildFile; fileRef = E230A11C1D03DB9E006181D8 /* BNCError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DCF4B011F438A2B00AF9AAB /* BNCLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BD7C3D91F27CEDB003696AF /* BNCLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BC158311FA79BDD00404895 /* BNCViewControllerManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC1582F1FA79BDD00404895 /* BNCViewControllerManager.h */; };
+		7BC158321FA79BDD00404895 /* BNCViewControllerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC158301FA79BDD00404895 /* BNCViewControllerManager.m */; };
+		7BC158351FA79BEF00404895 /* BranchEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC158331FA79BEE00404895 /* BranchEvent.h */; };
+		7BC158361FA79BEF00404895 /* BranchEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC158341FA79BEE00404895 /* BranchEvent.m */; };
 		7DA3BF1D1D889CE500CA8AE0 /* BranchContentDiscoverer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DA3BF171D889CE500CA8AE0 /* BranchContentDiscoverer.m */; };
 		7DA3BF1E1D889CE500CA8AE0 /* BranchContentDiscoverer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DA3BF181D889CE500CA8AE0 /* BranchContentDiscoverer.h */; };
 		7DA3BF1F1D889CE500CA8AE0 /* BranchContentDiscoveryManifest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DA3BF191D889CE500CA8AE0 /* BranchContentDiscoveryManifest.h */; };
@@ -172,8 +174,10 @@
 		4DAB17961EE8A31B0079EEB4 /* BranchUserCompletedActionRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchUserCompletedActionRequest.m; sourceTree = "<group>"; };
 		4DB567381E79FDAF00A8A324 /* BranchShareLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchShareLink.h; sourceTree = "<group>"; };
 		4DB567391E79FDAF00A8A324 /* BranchShareLink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchShareLink.m; sourceTree = "<group>"; };
-		4DCF4AFC1F43896F00AF9AAB /* BNCEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCEvent.h; sourceTree = "<group>"; };
-		4DCF4AFD1F43896F00AF9AAB /* BNCEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCEvent.m; sourceTree = "<group>"; };
+		7BC1582F1FA79BDD00404895 /* BNCViewControllerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCViewControllerManager.h; sourceTree = "<group>"; };
+		7BC158301FA79BDD00404895 /* BNCViewControllerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCViewControllerManager.m; sourceTree = "<group>"; };
+		7BC158331FA79BEE00404895 /* BranchEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchEvent.h; sourceTree = "<group>"; };
+		7BC158341FA79BEE00404895 /* BranchEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchEvent.m; sourceTree = "<group>"; };
 		7DA3BF171D889CE500CA8AE0 /* BranchContentDiscoverer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchContentDiscoverer.m; sourceTree = "<group>"; };
 		7DA3BF181D889CE500CA8AE0 /* BranchContentDiscoverer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoverer.h; sourceTree = "<group>"; };
 		7DA3BF191D889CE500CA8AE0 /* BranchContentDiscoveryManifest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchContentDiscoveryManifest.h; sourceTree = "<group>"; };
@@ -315,8 +319,6 @@
 				E230A11B1D03DB9E006181D8 /* BNCEncodingUtils.m */,
 				E230A11C1D03DB9E006181D8 /* BNCError.h */,
 				E230A11D1D03DB9E006181D8 /* BNCError.m */,
-				4DCF4AFC1F43896F00AF9AAB /* BNCEvent.h */,
-				4DCF4AFD1F43896F00AF9AAB /* BNCEvent.m */,
 				E2B9477C1D15E3C100F2270D /* BNCFabricAnswers.h */,
 				E2B9477D1D15E3C100F2270D /* BNCFabricAnswers.m */,
 				E230A11E1D03DB9E006181D8 /* BNCLinkCache.h */,
@@ -333,6 +335,8 @@
 				E230A12B1D03DB9E006181D8 /* BNCStrongMatchHelper.m */,
 				E230A12C1D03DB9E006181D8 /* BNCSystemObserver.h */,
 				E230A12D1D03DB9E006181D8 /* BNCSystemObserver.m */,
+				7BC1582F1FA79BDD00404895 /* BNCViewControllerManager.h */,
+				7BC158301FA79BDD00404895 /* BNCViewControllerManager.m */,
 				4D19C1C01DC110FA008D8B38 /* BNCXcode7Support.h */,
 				4D19C1C11DC110FB008D8B38 /* BNCXcode7Support.m */,
 				E230A12E1D03DB9E006181D8 /* Branch-SDK-Prefix.pch */,
@@ -351,6 +355,8 @@
 				E230A1351D03DB9E006181D8 /* BranchCSSearchableItemAttributeSet.h */,
 				E230A1361D03DB9E006181D8 /* BranchCSSearchableItemAttributeSet.m */,
 				E230A1371D03DB9E006181D8 /* BranchDeepLinkingController.h */,
+				7BC158331FA79BEE00404895 /* BranchEvent.h */,
+				7BC158341FA79BEE00404895 /* BranchEvent.m */,
 				E230A1381D03DB9E006181D8 /* BranchLinkProperties.h */,
 				E230A1391D03DB9E006181D8 /* BranchLinkProperties.m */,
 				4DB567381E79FDAF00A8A324 /* BranchShareLink.h */,
@@ -415,7 +421,6 @@
 				E230A16C1D03DB9E006181D8 /* BNCConfig.h in Headers */,
 				2BD7C3DD1F27CEDB003696AF /* BNCDebug.h in Headers */,
 				4DCF4B001F438A2B00AF9AAB /* BNCError.h in Headers */,
-				4DCF4AFE1F43896F00AF9AAB /* BNCEvent.h in Headers */,
 				E230A1751D03DB9E006181D8 /* BNCLinkCache.h in Headers */,
 				4DCF4B011F438A2B00AF9AAB /* BNCLog.h in Headers */,
 				E230A1771D03DB9E006181D8 /* BNCLinkData.h in Headers */,
@@ -425,6 +430,7 @@
 				4DAB17A61EE8A31B0079EEB4 /* BNCServerResponse.h in Headers */,
 				4DAB17A21EE8A31B0079EEB4 /* BNCServerRequest.h in Headers */,
 				4DAB17A41EE8A31B0079EEB4 /* BNCServerRequestQueue.h in Headers */,
+				7BC158311FA79BDD00404895 /* BNCViewControllerManager.h in Headers */,
 				4D19C1C21DC110FB008D8B38 /* BNCXcode7Support.h in Headers */,
 				E230A1861D03DB9E006181D8 /* Branch.h in Headers */,
 				4DAB179D1EE8A31B0079EEB4 /* BNCNetworkService.h in Headers */,
@@ -463,6 +469,7 @@
 				E230A18A1D03DB9E006181D8 /* BranchConstants.h in Headers */,
 				4DAB17BC1EE8A31B0079EEB4 /* BranchShortUrlSyncRequest.h in Headers */,
 				7DA3BF1F1D889CE500CA8AE0 /* BranchContentDiscoveryManifest.h in Headers */,
+				7BC158351FA79BEF00404895 /* BranchEvent.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -542,12 +549,14 @@
 				4DAB17AF1EE8A31B0079EEB4 /* BranchLoadRewardsRequest.m in Sources */,
 				E230A1931D03DB9E006181D8 /* BranchUniversalObject.m in Sources */,
 				4DAB17C11EE8A31B0079EEB4 /* BranchUserCompletedActionRequest.m in Sources */,
+				7BC158361FA79BEF00404895 /* BranchEvent.m in Sources */,
 				E230A1741D03DB9E006181D8 /* BNCError.m in Sources */,
 				4DAB17AD1EE8A31B0079EEB4 /* BranchInstallRequest.m in Sources */,
 				4DAB17A11EE8A31B0079EEB4 /* BNCServerInterface.m in Sources */,
 				4DAB179E1EE8A31B0079EEB4 /* BNCNetworkService.m in Sources */,
 				E230A1951D03DB9E006181D8 /* BranchView.m in Sources */,
 				4DAB17A51EE8A31B0079EEB4 /* BNCServerRequestQueue.m in Sources */,
+				7BC158321FA79BDD00404895 /* BNCViewControllerManager.m in Sources */,
 				E230A1901D03DB9E006181D8 /* BranchLinkProperties.m in Sources */,
 				4DAB17A91EE8A31B0079EEB4 /* BranchCloseRequest.m in Sources */,
 				4DAB17B71EE8A31B0079EEB4 /* BranchRegisterViewRequest.m in Sources */,
@@ -559,7 +568,6 @@
 				4DAB17B11EE8A31B0079EEB4 /* BranchLogoutRequest.m in Sources */,
 				4DAB17AB1EE8A31B0079EEB4 /* BranchCreditHistoryRequest.m in Sources */,
 				E230A1891D03DB9E006181D8 /* BranchActivityItemProvider.m in Sources */,
-				4DCF4AFF1F43896F00AF9AAB /* BNCEvent.m in Sources */,
 				4DAB17BB1EE8A31B0079EEB4 /* BranchShortUrlRequest.m in Sources */,
 				4D19C1C31DC110FB008D8B38 /* BNCXcode7Support.m in Sources */,
 				4D510D731F0D6014003D720B /* BNCDeepLinkViewControllerInstance.m in Sources */,


### PR DESCRIPTION
Relevant to #691.

This is a utility class to find the current view controller for use with `presentViewController:animated:completion:`. The implementation is probably not too far from correct. Please review it. At least this allows implementing this logic in one place and reusing it throughout the SDK (and in wrapper SDKs). This can replace the implementation in Parth's PR that was borrowed from RN (and that can be replaced if this is released).

I also want to write some tests for this, but wanted to give everyone time to have a look.
