### PR TITLE
Added Apple Search Ads Time Out

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCTestCase.h
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCTestCase.h
@@ -11,7 +11,7 @@
 #import "Branch.h"
 #import "NSString+Branch.h"
 
-static inline dispatch_time_t BNCDispatchTimeFromSeconds(NSTimeInterval seconds)	{
+static inline dispatch_time_t BNCDispatchTimeFromSeconds(NSTimeInterval seconds) {
 	return dispatch_time(DISPATCH_TIME_NOW, seconds * NSEC_PER_SEC);
 }
 


### PR DESCRIPTION
Apple Search Ads weren't timing out on iPad which prevented Branch initialization. I added a 10 second timeout for search ads before initialization continues.

