### PR TITLE
Fix for crash on pre iOS 11 where the application delegate does not have a window variable

### DIFF
--- a/Branch-SDK/Branch-SDK/UIViewController+Branch.m
+++ b/Branch-SDK/Branch-SDK/UIViewController+Branch.m
@@ -15,7 +15,9 @@
     if (UIApplicationClass) {
         UIWindow *keyWindow = nil;
 
-        keyWindow = [UIApplicationClass sharedApplication].delegate.window;
+        if ([[UIApplicationClass sharedApplication].delegate respondsToSelector:@selector(window)]) {
+            keyWindow = [UIApplicationClass sharedApplication].delegate.window;
+        }
         if (keyWindow && !keyWindow.isHidden && keyWindow.rootViewController) return keyWindow;
 
         keyWindow = [UIApplicationClass sharedApplication].keyWindow;


### PR DESCRIPTION
We were seeing a crash on  < iOS 11 along the lines of:
`[AppDelegate window]; unrecognised selector sent to instance`

The `window` var on the UIApplicationDelegate protocol is optional - and for a couple of reasons we don't actually have it in our app delegate.

This PR just wraps the crashing call in `respondsToSelector`

 On the devices I tested with this change - the keyWindow was always found on the next attempt:
`keyWindow = [UIApplicationClass sharedApplication].keyWindow;`

I'm unsure why this is not happening on iOS 11 btw