### PR TITLE
Fix blacklist open with URI scheme DEVEX-341

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -53,6 +53,7 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 
 @property (strong, atomic) NSArray<NSString*> *URLBlackList;
 @property (assign, atomic) NSInteger URLBlackListVersion;
+@property (assign, atomic) BOOL blacklistURLOpen;
 
 @property (assign, atomic) BOOL trackingDisabled;
 - (void) clearTrackingInformation;

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -571,6 +571,19 @@ static NSString * const BRANCH_PREFS_KEY_ANALYTICS_MANIFEST = @"bnc_branch_analy
     }
 }
 
+- (BOOL) blacklistURLOpen {
+    @synchronized(self) {
+        return [self readBoolFromDefaults:@"blacklistURLOpen"];
+    }
+}
+
+- (void) setBlacklistURLOpen:(BOOL)value {
+    @synchronized(self) {
+        [self writeBoolToDefaults:@"blacklistURLOpen" value:value];
+    }
+}
+
+
 - (BOOL) trackingDisabled {
     @synchronized(self) {
         NSNumber *b = (id) [self readObjectFromDefaults:@"trackingDisabled"];

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -718,7 +718,9 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
     }
     if (blackListPattern) {
         self.preferenceHelper.blacklistURLOpen = YES;
-        [self handleUniversalDeepLink_private:blackListPattern fromSelf:isFromSelf];
+        self.preferenceHelper.externalIntentURI = blackListPattern;
+        self.preferenceHelper.referringURL = blackListPattern;
+        [self initUserSessionAndCallCallback:!self.isInitialized];
         return NO;
     }
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -717,10 +717,12 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
         blackListPattern = [_userURLBlackList blackListPatternMatchingURL:url];
     }
     if (blackListPattern) {
+        self.preferenceHelper.blacklistURLOpen = YES;
         [self handleUniversalDeepLink_private:blackListPattern fromSelf:isFromSelf];
         return NO;
     }
 
+    self.preferenceHelper.blacklistURLOpen = NO;
     self.preferenceHelper.referringURL = nil;
     self.preferenceHelper.externalIntentURI = nil;
     self.preferenceHelper.universalLinkUrl = nil;

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -721,6 +721,10 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
         return NO;
     }
 
+    self.preferenceHelper.referringURL = nil;
+    self.preferenceHelper.externalIntentURI = nil;
+    self.preferenceHelper.universalLinkUrl = nil;
+
     NSString *scheme = [url scheme];
     if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) {
         return [self handleUniversalDeepLink_private:url.absoluteString fromSelf:isFromSelf];

--- a/Branch-SDK/Branch-SDK/Networking/BNCServerInterface.m
+++ b/Branch-SDK/Branch-SDK/Networking/BNCServerInterface.m
@@ -612,7 +612,6 @@ exit:
               (prefs.spotlightIdentifier.length > 0 ) ||
               (prefs.universalLinkUrl.length > 0))) {
             // Allow this network operation since it's an open/install to resolve a link.
-            NSLog(@"Yope!"); // EBS eDebug
         } else {
             [[BNCPreferenceHelper preferenceHelper] clearTrackingInformation];
             NSError *error = [NSError branchErrorWithCode:BNCTrackingDisabledError];

--- a/Branch-SDK/Branch-SDK/Networking/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Networking/Requests/BranchOpenRequest.m
@@ -137,18 +137,25 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    if (preferenceHelper.blacklistURLOpen) {
+        // Ignore this response from the server. Dummy up a response:
+        preferenceHelper.blacklistURLOpen = NO;
+        error = nil;
+        response.data = @{
+            BRANCH_RESPONSE_KEY_SESSION_DATA: @{
+                BRANCH_RESPONSE_KEY_CLICKED_BRANCH_LINK: @0
+            }
+        };
+    } else
     if (error) {
         [BranchOpenRequest releaseOpenResponseLock];
         if (self.callback) {
             self.callback(NO, error);
         }
-        // EBS
-//        if ([response.statusCode integerValue] == 400)
-//            [BNCPreferenceHelper preferenceHelper].universalLinkUrl = nil;
         return;
     }
 
-    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
     NSDictionary *data = response.data;
     
     // Handle possibly mis-parsed identity.

--- a/Branch-SDK/Branch-SDK/Networking/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Networking/Requests/BranchOpenRequest.m
@@ -138,9 +138,8 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-    if (preferenceHelper.blacklistURLOpen) {
+    if (error && preferenceHelper.blacklistURLOpen) {
         // Ignore this response from the server. Dummy up a response:
-        preferenceHelper.blacklistURLOpen = NO;
         error = nil;
         response.data = @{
             BRANCH_RESPONSE_KEY_SESSION_DATA: @{
@@ -253,6 +252,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
     preferenceHelper.externalIntentURI = nil;
     preferenceHelper.appleSearchAdNeedsSend = NO;
     preferenceHelper.referringURL = referringURL;
+    preferenceHelper.blacklistURLOpen = NO;
 
     NSString *string = BNCStringFromWireFormat(data[BRANCH_RESPONSE_KEY_BRANCH_IDENTITY]);
     if (string) preferenceHelper.identityID = string;

--- a/Branch-SDK/Branch-SDK/Networking/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Networking/Requests/BranchOpenRequest.m
@@ -142,6 +142,9 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
         if (self.callback) {
             self.callback(NO, error);
         }
+        // EBS
+//        if ([response.statusCode integerValue] == 400)
+//            [BNCPreferenceHelper preferenceHelper].universalLinkUrl = nil;
         return;
     }
 

--- a/Branch-TestBed/Branch-SDK-Tests/BNCURLBlackList.Test.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCURLBlackList.Test.m
@@ -23,6 +23,11 @@
 - (void) setUp {
     [BNCPreferenceHelper preferenceHelper].URLBlackList = nil;
     [BNCPreferenceHelper preferenceHelper].URLBlackListVersion = 0;
+    [BNCPreferenceHelper preferenceHelper].blacklistURLOpen = NO;
+}
+
+- (void) tearDown {
+    [BNCPreferenceHelper preferenceHelper].blacklistURLOpen = NO;
 }
 
 - (void)testListDownLoad {
@@ -30,7 +35,7 @@
     BNCURLBlackList *blackList = [BNCURLBlackList new];
     [blackList refreshBlackListFromServerWithCompletion:^ (NSError*error, NSArray*list) {
         XCTAssertNil(error);
-        XCTAssertTrue(list.count == 7);
+        XCTAssertTrue(list.count == 6);
         [expectation fulfill];
     }];
     [self awaitExpectations];

--- a/Branch-TestBed/Branch-TestBed-UITests/UITestBed/Info.plist
+++ b/Branch-TestBed/Branch-TestBed-UITests/UITestBed/Info.plist
@@ -24,6 +24,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>branchuitest</string>
+				<string>fb123</string>
 			</array>
 		</dict>
 	</array>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 Branch iOS SDK Change Log
 
+- v0.24.2
+  * _*Master Release*_ - April 19, 2018
+  * Fixed a bug where a opening a blacklisted URI scheme would cause an HTTP status 400 for each
+    Branch open until the app was opened with a universal link.
+
 - v0.24.1
   * _*Master Release*_ - April 5, 2018
   * Updated the SDK for Xcode 9.3 and Swift 4.1.


### PR DESCRIPTION
* Added code that clears the blacklisted URL after sending the regex pattern to the server.
* Removed an old NSLog from debugging.
