### PR TITLE
Podspec: Add SafariServices for `without-IDFA` subspec

### DIFF
--- a/Branch.podspec
+++ b/Branch.podspec
@@ -35,7 +35,7 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
   s.subspec 'without-IDFA' do |idfa|
     idfa.source_files = source_files
     idfa.private_header_files = "Branch-SDK/Fabric/*.h"
-    idfa.frameworks = 'MobileCoreServices'
+    idfa.frameworks = 'MobileCoreServices', 'SafariServices'
   end
 
   s.subspec 'without-Safari' do |safari|


### PR DESCRIPTION
Updated subspec for podspec in order to include `SafariServices` framework with `without-IDFA` subspec for more reliable session matching.