### PR TITLE
Don't send IDFA when in debug mode. DEVEX-685

### DIFF
--- a/Branch-SDK-Tests/Branch-SDK-Tests/BNCURLBlackList.Test.m
+++ b/Branch-SDK-Tests/Branch-SDK-Tests/BNCURLBlackList.Test.m
@@ -148,9 +148,8 @@
         NSString* link = dictionary[@"external_intent_uri"];
         NSString *pattern = @"^(?i)((http|https):\\/\\/).*[\\/|?|#].*\\b(password|o?auth|o?auth.?token|access|access.?token)\\b";
         NSLog(@"\n   Link: '%@'\nPattern: '%@'\n.", link, pattern);
-        if ([link isEqualToString:pattern]) {
-            [expectation fulfill];
-        }
+        XCTAssertEqualObjects(link, pattern);
+        [expectation fulfill];
     });
 
     [branch clearNetworkQueue];
@@ -181,10 +180,8 @@
         NSString* link = dictionary[@"external_intent_uri"];
         NSString *pattern = @"\\/bob\\/";
         NSLog(@"\n   Link: '%@'\nPattern: '%@'\n.", link, pattern);
-
-        if ([link isEqualToString:pattern]) {
-            [expectation fulfill];
-        }
+        XCTAssertEqualObjects(link, pattern);
+        [expectation fulfill];
     });
 
     [branch clearNetworkQueue];

--- a/Branch-SDK/Branch-SDK/BNCCommerceEvent.m
+++ b/Branch-SDK/Branch-SDK/BNCCommerceEvent.m
@@ -578,7 +578,7 @@ NSArray<BNCCurrency>* BNCCurrencyAllCurrencies(void) {
 	if (self.commerceDictionary)
 		params[@"commerce_data"] = self.commerceDictionary;
     if (preferenceHelper.limitFacebookTracking)
-        params[@"limit_facebook_tracking"] = CFBridgingRelease(kCFBooleanTrue);
+        params[@"limit_facebook_tracking"] = (__bridge NSNumber*) kCFBooleanTrue;
 
 	NSString *URL = [preferenceHelper getAPIURL:BRANCH_REQUEST_ENDPOINT_USER_COMPLETED_ACTION];
     [serverInterface postRequest:params

--- a/Branch-SDK/Branch-SDK/BNCDeviceInfo.m
+++ b/Branch-SDK/Branch-SDK/BNCDeviceInfo.m
@@ -430,7 +430,9 @@ exit:
     addString(osVersion,            os_version);
     addString(extensionType,        environment);
     addString(vendorId,             idfv);
-    addString(adId,                 idfa);
+    if (![BNCPreferenceHelper preferenceHelper].isDebug) {
+        addString(adId,             idfa);
+    }
     addString(browserUserAgent,     user_agent);
     addString(country,              country);
     addString(language,             language);

--- a/Branch-SDK/Branch-SDK/BNCDeviceInfo.m
+++ b/Branch-SDK/Branch-SDK/BNCDeviceInfo.m
@@ -430,7 +430,9 @@ exit:
     addString(osVersion,            os_version);
     addString(extensionType,        environment);
     addString(vendorId,             idfv);
-    if (![BNCPreferenceHelper preferenceHelper].isDebug) {
+    if ([BNCPreferenceHelper preferenceHelper].isDebug) {
+        dictionary[@"unidentified_device"] = (__bridge NSNumber*) kCFBooleanTrue;
+    } else {
         addString(adId,             idfa);
     }
     addString(browserUserAgent,     user_agent);
@@ -448,7 +450,7 @@ exit:
     #include "BNCFieldDefines.h"
 
     if (!self.isAdTrackingEnabled)
-        dictionary[@"limit_ad_tracking"] = CFBridgingRelease(kCFBooleanTrue);
+        dictionary[@"limit_ad_tracking"] = (__bridge NSNumber*) kCFBooleanTrue;
 
     NSString *s = nil;
     BNCPreferenceHelper *preferences = [BNCPreferenceHelper preferenceHelper];
@@ -460,7 +462,7 @@ exit:
     if (s.length) dictionary[@"device_fingerprint_id"] = s;
 
     if (preferences.limitFacebookTracking)
-        dictionary[@"limit_facebook_tracking"] = CFBridgingRelease(kCFBooleanTrue);
+        dictionary[@"limit_facebook_tracking"] = (__bridge NSNumber*) kCFBooleanTrue;
 
     dictionary[@"sdk"] = @"ios";
     dictionary[@"sdk_version"] = BNC_SDK_VERSION;

--- a/Branch-SDK/Branch-SDK/BNCFieldDefines.h
+++ b/Branch-SDK/Branch-SDK/BNCFieldDefines.h
@@ -138,7 +138,7 @@
 
     #define addBoolean(field, name) { \
         if (self.field) { \
-            dictionary[@#name] = CFBridgingRelease(kCFBooleanTrue); \
+            dictionary[@#name] = (__bridge NSNumber*) kCFBooleanTrue; \
         } \
     }
 

--- a/Branch-SDK/Branch-SDK/Networking/Requests/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/Networking/Requests/BranchOpenRequest.m
@@ -63,7 +63,7 @@
     [self safeSetValue:preferenceHelper.universalLinkUrl forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:params];
     [self safeSetValue:preferenceHelper.externalIntentURI forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:params];
     if (preferenceHelper.limitFacebookTracking)
-        params[@"limit_facebook_tracking"] = CFBridgingRelease(kCFBooleanTrue);
+        params[@"limit_facebook_tracking"] = (__bridge NSNumber*) kCFBooleanTrue;
 
     NSMutableDictionary *cdDict = [[NSMutableDictionary alloc] init];
     BranchContentDiscoveryManifest *contentDiscoveryManifest = [BranchContentDiscoveryManifest getInstance];

--- a/Branch-SDK/Branch-SDK/Networking/Requests/BranchUserCompletedActionRequest.m
+++ b/Branch-SDK/Branch-SDK/Networking/Requests/BranchUserCompletedActionRequest.m
@@ -54,7 +54,7 @@
     params[BRANCH_REQUEST_KEY_BRANCH_IDENTITY] = preferenceHelper.identityID;
     params[BRANCH_REQUEST_KEY_SESSION_ID] = preferenceHelper.sessionID;
     if (preferenceHelper.limitFacebookTracking)
-        params[@"limit_facebook_tracking"] = CFBridgingRelease(kCFBooleanTrue);
+        params[@"limit_facebook_tracking"] = (__bridge NSNumber*) kCFBooleanTrue;
 
     if (self.state) {
         params[BRANCH_REQUEST_KEY_STATE] = self.state;


### PR DESCRIPTION
* Don't send idfa for v2-events when in debug mode.
* Fixed some unit test conditions.

