### PR TITLE
README: Fix Objective-C function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ For best results use the Branch standard event names defined in `BranchEvent.h`.
 ###### Objective-C
 
 ```objc
-[BranchEvent.customEventWithName(@"User_Scanned_Item") logEvent];
+[[BranchEvent customEventWithName:@"User_Scanned_Item"] logEvent];
 ```
 
 ###### Swift


### PR DESCRIPTION
Objective-C function was being called with a "swifty" syntax and caused an error in Xcode.
Similar to Issue #855 which was fixed in 6d6a9049e5c5e21ea77aa113d5e449bf1150155f.

PR submitted against `master` branch because it's a docs change.