### PR TITLE
[INTENG-4289] Fixed crash on validateSDKIntegration()

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch+Validator.m
+++ b/Branch-SDK/Branch-SDK/Branch+Validator.m
@@ -72,7 +72,7 @@ static inline void BNCAfterSecondsPerformBlockOnMainThread(NSTimeInterval second
     NSLog(@"-- Checking for bundle identifier correctness ---");
     NSString *serverBundleIdentifier = response.data[@"ios_bundle_id"];
     NSString *clientBundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
-    NSString *bundleIdentifier = [serverBundleIdentifier isEqualToString:clientBundleIdentifier] ? passString : errorString;
+    NSString *bundleIdentifier = [[serverBundleIdentifier isKindOfClass:NSString.class] ? serverBundleIdentifier : @"" isEqualToString:clientBundleIdentifier] ? passString : errorString;
     NSString *bundleIdentifierMessage = [NSString stringWithFormat:@"%@: Dashboard Link Settings page '%@' compared to client side '%@'", bundleIdentifier, serverBundleIdentifier, clientBundleIdentifier];
     NSLog(@"%@",bundleIdentifierMessage);
     NSLog(@"-------------------------------------------------");
@@ -113,7 +113,7 @@ static inline void BNCAfterSecondsPerformBlockOnMainThread(NSTimeInterval second
             kFailMark,  serverUriScheme];
     }
 
-    if ([serverBundleIdentifier isEqualToString:clientBundleIdentifier]) {
+    if ([[serverBundleIdentifier isKindOfClass:NSString.class] ? serverBundleIdentifier : @"" isEqualToString:clientBundleIdentifier]) {
         alertString = [alertString stringByAppendingFormat:@"%@App Bundle ID matches:\n\t'%@'\n",
             kPassMark,  serverBundleIdentifier];
     } else {

--- a/Branch-SDK/Branch-SDK/Branch+Validator.m
+++ b/Branch-SDK/Branch-SDK/Branch+Validator.m
@@ -70,9 +70,9 @@ static inline void BNCAfterSecondsPerformBlockOnMainThread(NSTimeInterval second
     NSLog(@"-------------------------------------------------");
 
     NSLog(@"-- Checking for bundle identifier correctness ---");
-    NSString *serverBundleIdentifier = response.data[@"ios_bundle_id"];
+    NSString *serverBundleIdentifier = [response.data[@"ios_bundle_id"] isKindOfClass:NSString.class] ? response.data[@"ios_bundle_id"] : @"";
     NSString *clientBundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
-    NSString *bundleIdentifier = [[serverBundleIdentifier isKindOfClass:NSString.class] ? serverBundleIdentifier : @"" isEqualToString:clientBundleIdentifier] ? passString : errorString;
+    NSString *bundleIdentifier = [serverBundleIdentifier isEqualToString:clientBundleIdentifier] ? passString : errorString;
     NSString *bundleIdentifierMessage = [NSString stringWithFormat:@"%@: Dashboard Link Settings page '%@' compared to client side '%@'", bundleIdentifier, serverBundleIdentifier, clientBundleIdentifier];
     NSLog(@"%@",bundleIdentifierMessage);
     NSLog(@"-------------------------------------------------");
@@ -113,7 +113,7 @@ static inline void BNCAfterSecondsPerformBlockOnMainThread(NSTimeInterval second
             kFailMark,  serverUriScheme];
     }
 
-    if ([[serverBundleIdentifier isKindOfClass:NSString.class] ? serverBundleIdentifier : @"" isEqualToString:clientBundleIdentifier]) {
+    if ([serverBundleIdentifier isEqualToString:clientBundleIdentifier]) {
         alertString = [alertString stringByAppendingFormat:@"%@App Bundle ID matches:\n\t'%@'\n",
             kPassMark,  serverBundleIdentifier];
     } else {


### PR DESCRIPTION
Fixed a crash which occurred when the serverBundleIdentifier returned by the API is NULL
JIRA: [INTENG-4289](https://branch.atlassian.net/browse/INTENG-4289) 

Steps to reproduce:
1. Remove Bundle ID from the Link Settings page on the dashboard 
2. Run the SDK integration validation on the app. Branch.getInstance().validateSDKIntegration()
