### PR TITLE
DEVEX-875 add new standard events

### DIFF
--- a/Branch-SDK-Tests/BranchEvent.Test.m
+++ b/Branch-SDK-Tests/BranchEvent.Test.m
@@ -18,6 +18,8 @@
 
 @interface BranchEvent()
 
+- (NSString *)jsonStringForAdType:(BranchEventAdType)adType;
+
 // private BranchEvent methods used to check data before sending to network service.
 - (NSDictionary *)buildEventDictionary;
 - (BranchEventRequest *)buildRequestWithEventDictionary:(NSDictionary *)eventDictionary;
@@ -297,10 +299,10 @@
     XCTAssertNil(eventDictionary[@"content_items"]);
 
     NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"userID"] isEqualToString:@"test_userID@branch.io"]);
-    XCTAssert([eventData[@"facebookUserID"] isEqualToString:@"test_facebook@branch.io"]);
-    XCTAssert([eventData[@"googleUserID"] isEqualToString:@"test_google@branch.io"]);
-    XCTAssert([eventData[@"twitterUserID"] isEqualToString:@"test_twitter@branch.io"]);
+    XCTAssert([eventData[@"user_id"] isEqualToString:@"test_userID@branch.io"]);
+    XCTAssert([eventData[@"facebook_user_id"] isEqualToString:@"test_facebook@branch.io"]);
+    XCTAssert([eventData[@"google_user_id"] isEqualToString:@"test_google@branch.io"]);
+    XCTAssert([eventData[@"twitter_user_id"] isEqualToString:@"test_twitter@branch.io"]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
@@ -330,10 +332,10 @@
     XCTAssertNotNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"userID"] isEqualToString:@"test_userID@branch.io"]);
-    XCTAssert([eventData[@"facebookUserID"] isEqualToString:@"test_facebook@branch.io"]);
-    XCTAssert([eventData[@"googleUserID"] isEqualToString:@"test_google@branch.io"]);
-    XCTAssert([eventData[@"twitterUserID"] isEqualToString:@"test_twitter@branch.io"]);
+    XCTAssert([eventData[@"user_id"] isEqualToString:@"test_userID@branch.io"]);
+    XCTAssert([eventData[@"facebook_user_id"] isEqualToString:@"test_facebook@branch.io"]);
+    XCTAssert([eventData[@"google_user_id"] isEqualToString:@"test_google@branch.io"]);
+    XCTAssert([eventData[@"twitter_user_id"] isEqualToString:@"test_twitter@branch.io"]);
  
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
@@ -369,10 +371,10 @@
     XCTAssertNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"userID"] isEqualToString:@"test_userID@branch.io"]);
-    XCTAssert([eventData[@"facebookUserID"] isEqualToString:@"test_facebook@branch.io"]);
-    XCTAssert([eventData[@"googleUserID"] isEqualToString:@"test_google@branch.io"]);
-    XCTAssert([eventData[@"twitterUserID"] isEqualToString:@"test_twitter@branch.io"]);
+    XCTAssert([eventData[@"user_id"] isEqualToString:@"test_userID@branch.io"]);
+    XCTAssert([eventData[@"facebook_user_id"] isEqualToString:@"test_facebook@branch.io"]);
+    XCTAssert([eventData[@"google_user_id"] isEqualToString:@"test_google@branch.io"]);
+    XCTAssert([eventData[@"twitter_user_id"] isEqualToString:@"test_twitter@branch.io"]);
     XCTAssert([eventData[@"latitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
     XCTAssert([eventData[@"longitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
     XCTAssert([eventData[@"altitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
@@ -410,10 +412,10 @@
     XCTAssertNotNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"userID"] isEqualToString:@"test_userID@branch.io"]);
-    XCTAssert([eventData[@"facebookUserID"] isEqualToString:@"test_facebook@branch.io"]);
-    XCTAssert([eventData[@"googleUserID"] isEqualToString:@"test_google@branch.io"]);
-    XCTAssert([eventData[@"twitterUserID"] isEqualToString:@"test_twitter@branch.io"]);
+    XCTAssert([eventData[@"user_id"] isEqualToString:@"test_userID@branch.io"]);
+    XCTAssert([eventData[@"facebook_user_id"] isEqualToString:@"test_facebook@branch.io"]);
+    XCTAssert([eventData[@"google_user_id"] isEqualToString:@"test_google@branch.io"]);
+    XCTAssert([eventData[@"twitter_user_id"] isEqualToString:@"test_twitter@branch.io"]);
     XCTAssert([eventData[@"latitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
     XCTAssert([eventData[@"longitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
     XCTAssert([eventData[@"altitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
@@ -590,7 +592,7 @@
 
 - (void)testStandardClickAdEvent {
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventClickAd];
-    event.adType = @(BranchEventAdTypeBanner);
+    event.adType = BranchEventAdTypeBanner;
 
     BranchUniversalObject *buo = [BranchUniversalObject new];
     buo.canonicalIdentifier = @"item/12345";
@@ -609,7 +611,7 @@
     XCTAssertNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"adType"] isEqual:@(BranchEventAdTypeBanner)]);
+    XCTAssert([eventData[@"ad_type"] isEqual:[event jsonStringForAdType:event.adType]]);
 
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
@@ -618,7 +620,7 @@
 - (void)testCustomClickAdEvent {
     
     BranchEvent *event = [BranchEvent customEventWithName:@"CLICK_AD"];
-    event.adType = @(BranchEventAdTypeBanner);
+    event.adType = BranchEventAdTypeBanner;
     
     BranchUniversalObject *buo = [BranchUniversalObject new];
     buo.canonicalIdentifier = @"item/12345";
@@ -637,7 +639,7 @@
     XCTAssertNotNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"adType"] isEqual:@(BranchEventAdTypeBanner)]);
+    XCTAssert([eventData[@"ad_type"] isEqual:[event jsonStringForAdType:event.adType]]);
 
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
@@ -645,7 +647,7 @@
 
 - (void)testStandardViewAdEvent {
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
-    event.adType = @(BranchEventAdTypeBanner);
+    event.adType = BranchEventAdTypeBanner;
     
     BranchUniversalObject *buo = [BranchUniversalObject new];
     buo.canonicalIdentifier = @"item/12345";
@@ -664,7 +666,7 @@
     XCTAssertNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"adType"] isEqual:@(BranchEventAdTypeBanner)]);
+    XCTAssert([eventData[@"ad_type"] isEqual:[event jsonStringForAdType:event.adType]]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
@@ -673,7 +675,7 @@
 - (void)testCustomViewAdEvent {
     
     BranchEvent *event = [BranchEvent customEventWithName:@"VIEW_AD"];
-    event.adType = @(BranchEventAdTypeBanner);
+    event.adType = BranchEventAdTypeBanner;
     
     BranchUniversalObject *buo = [BranchUniversalObject new];
     buo.canonicalIdentifier = @"item/12345";
@@ -692,10 +694,35 @@
     XCTAssertNotNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"adType"] isEqual:@(BranchEventAdTypeBanner)]);
+    XCTAssert([eventData[@"ad_type"] isEqual:[event jsonStringForAdType:event.adType]]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+}
+
+- (void)testJsonStringForAdTypeNone {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
+    XCTAssertNil([event jsonStringForAdType:BranchEventAdTypeNone]);
+}
+    
+- (void)testJsonStringForAdTypeBanner {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
+    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeBanner] isEqualToString:@"banner"]);
+}
+
+- (void)testJsonStringForAdTypeInterstitial {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
+    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeInterstitial] isEqualToString:@"interstitial"]);
+}
+
+- (void)testJsonStringForAdTypeRewardedVideo {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
+    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeRewardedVideo] isEqualToString:@"rewarded_video"]);
+}
+
+- (void)testJsonStringForAdTypeNative {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
+    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeNative] isEqualToString:@"native"]);
 }
 
 @end

--- a/Branch-SDK-Tests/BranchEvent.Test.m
+++ b/Branch-SDK-Tests/BranchEvent.Test.m
@@ -277,10 +277,6 @@
 - (void)testStandardInviteEvent {
     
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventInvite];
-    event.userID = @"test_userID@branch.io";
-    event.facebookUserID = @"test_facebook@branch.io";
-    event.googleUserID = @"test_google@branch.io";
-    event.twitterUserID = @"test_twitter@branch.io";
 
     BranchUniversalObject *buo = [BranchUniversalObject new];
     buo.canonicalIdentifier = @"item/12345";
@@ -298,12 +294,6 @@
     XCTAssert([eventDictionary[@"name"] isEqualToString:@"INVITE"]);
     XCTAssertNil(eventDictionary[@"content_items"]);
 
-    NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"user_id"] isEqualToString:@"test_userID@branch.io"]);
-    XCTAssert([eventData[@"facebook_user_id"] isEqualToString:@"test_facebook@branch.io"]);
-    XCTAssert([eventData[@"google_user_id"] isEqualToString:@"test_google@branch.io"]);
-    XCTAssert([eventData[@"twitter_user_id"] isEqualToString:@"test_twitter@branch.io"]);
-    
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
 }
@@ -311,10 +301,6 @@
 - (void)testCustomInviteEvent {
     
     BranchEvent *event = [BranchEvent customEventWithName:@"INVITE"];
-    event.userID = @"test_userID@branch.io";
-    event.facebookUserID = @"test_facebook@branch.io";
-    event.googleUserID = @"test_google@branch.io";
-    event.twitterUserID = @"test_twitter@branch.io";
     
     BranchUniversalObject *buo = [BranchUniversalObject new];
     buo.canonicalIdentifier = @"item/12345";
@@ -331,12 +317,6 @@
     XCTAssert([eventDictionary[@"name"] isEqualToString:@"INVITE"]);
     XCTAssertNotNil(eventDictionary[@"content_items"]);
     
-    NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"user_id"] isEqualToString:@"test_userID@branch.io"]);
-    XCTAssert([eventData[@"facebook_user_id"] isEqualToString:@"test_facebook@branch.io"]);
-    XCTAssert([eventData[@"google_user_id"] isEqualToString:@"test_google@branch.io"]);
-    XCTAssert([eventData[@"twitter_user_id"] isEqualToString:@"test_twitter@branch.io"]);
- 
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
 }
@@ -344,16 +324,7 @@
 - (void)testStandardLoginEvent {
     
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventLogin];
-    event.userID = @"test_userID@branch.io";
-    event.facebookUserID = @"test_facebook@branch.io";
-    event.googleUserID = @"test_google@branch.io";
-    event.twitterUserID = @"test_twitter@branch.io";
-    event.userName = @"test_userName";
-    event.userEmail = @"test@branch.io";
-    event.latitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
-    event.longitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
-    event.altitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
-
+    
     BranchUniversalObject *buo = [BranchUniversalObject new];
     buo.canonicalIdentifier = @"item/12345";
     buo.canonicalUrl        = @"https://branch.io/deepviews";
@@ -370,15 +341,6 @@
     XCTAssert([eventDictionary[@"name"] isEqualToString:@"LOGIN"]);
     XCTAssertNil(eventDictionary[@"content_items"]);
     
-    NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"user_id"] isEqualToString:@"test_userID@branch.io"]);
-    XCTAssert([eventData[@"facebook_user_id"] isEqualToString:@"test_facebook@branch.io"]);
-    XCTAssert([eventData[@"google_user_id"] isEqualToString:@"test_google@branch.io"]);
-    XCTAssert([eventData[@"twitter_user_id"] isEqualToString:@"test_twitter@branch.io"]);
-    XCTAssert([eventData[@"latitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
-    XCTAssert([eventData[@"longitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
-    XCTAssert([eventData[@"altitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
-
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
 }
@@ -386,15 +348,6 @@
 - (void)testCustomLoginEvent {
     
     BranchEvent *event = [BranchEvent customEventWithName:@"LOGIN"];
-    event.userID = @"test_userID@branch.io";
-    event.facebookUserID = @"test_facebook@branch.io";
-    event.googleUserID = @"test_google@branch.io";
-    event.twitterUserID = @"test_twitter@branch.io";
-    event.userName = @"test_userName";
-    event.userEmail = @"test@branch.io";
-    event.latitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
-    event.longitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
-    event.altitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
 
     BranchUniversalObject *buo = [BranchUniversalObject new];
     buo.canonicalIdentifier = @"item/12345";
@@ -410,15 +363,6 @@
     XCTAssertNotNil(eventDictionary);
     XCTAssert([eventDictionary[@"name"] isEqualToString:@"LOGIN"]);
     XCTAssertNotNil(eventDictionary[@"content_items"]);
-    
-    NSDictionary *eventData = eventDictionary[@"event_data"];
-    XCTAssert([eventData[@"user_id"] isEqualToString:@"test_userID@branch.io"]);
-    XCTAssert([eventData[@"facebook_user_id"] isEqualToString:@"test_facebook@branch.io"]);
-    XCTAssert([eventData[@"google_user_id"] isEqualToString:@"test_google@branch.io"]);
-    XCTAssert([eventData[@"twitter_user_id"] isEqualToString:@"test_twitter@branch.io"]);
-    XCTAssert([eventData[@"latitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
-    XCTAssert([eventData[@"longitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
-    XCTAssert([eventData[@"altitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
@@ -707,22 +651,22 @@
     
 - (void)testJsonStringForAdTypeBanner {
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
-    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeBanner] isEqualToString:@"banner"]);
+    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeBanner] isEqualToString:@"BANNER"]);
 }
 
 - (void)testJsonStringForAdTypeInterstitial {
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
-    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeInterstitial] isEqualToString:@"interstitial"]);
+    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeInterstitial] isEqualToString:@"INTERSTITIAL"]);
 }
 
 - (void)testJsonStringForAdTypeRewardedVideo {
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
-    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeRewardedVideo] isEqualToString:@"rewarded_video"]);
+    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeRewardedVideo] isEqualToString:@"REWARDED_VIDEO"]);
 }
 
 - (void)testJsonStringForAdTypeNative {
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
-    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeNative] isEqualToString:@"native"]);
+    XCTAssertTrue([[event jsonStringForAdType:BranchEventAdTypeNative] isEqualToString:@"NATIVE"]);
 }
 
 @end

--- a/Branch-SDK-Tests/BranchEvent.Test.m
+++ b/Branch-SDK-Tests/BranchEvent.Test.m
@@ -204,7 +204,7 @@
         NSLog(@"URL: %@.", url);
         NSLog(@"Body: %@.", parameters);
 
-        if ([url containsString:@"branch.io/v2/event/custom"]) {
+        if ([url containsString:@"branch.io/v2/event/standard"]) {
             XCTAssertEqualObjects(expectedRequest, parameters);
             [expectation fulfill];
         } else {
@@ -317,7 +317,7 @@
     XCTAssertNotNil(eventDictionary[@"content_items"]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
-    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
 }
 
 - (void)testStandardLoginEvent {
@@ -363,7 +363,7 @@
     XCTAssertNotNil(eventDictionary[@"content_items"]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
-    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
 }
 
 - (void)testStandardReserveEvent {
@@ -411,7 +411,7 @@
     XCTAssertNotNil(eventDictionary[@"content_items"]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
-    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
 }
 
 - (void)testStandardSubscribeEvent {
@@ -469,7 +469,7 @@
     XCTAssert([eventData[@"revenue"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
-    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
 }
 
 - (void)testStandardStartTrialEvent {
@@ -527,7 +527,7 @@
     XCTAssert([eventData[@"revenue"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
-    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
 }
 
 - (void)testStandardClickAdEvent {
@@ -581,7 +581,7 @@
     XCTAssert([eventData[@"ad_type"] isEqual:[event jsonStringForAdType:event.adType]]);
 
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
-    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
 }
 
 - (void)testStandardViewAdEvent {
@@ -635,7 +635,7 @@
     XCTAssert([eventData[@"ad_type"] isEqual:[event jsonStringForAdType:event.adType]]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
-    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
 }
 
 - (void)testJsonStringForAdTypeNone {

--- a/Branch-SDK-Tests/BranchEvent.Test.m
+++ b/Branch-SDK-Tests/BranchEvent.Test.m
@@ -16,6 +16,14 @@
 - (void) processNextQueueItem;
 @end
 
+@interface BranchEvent()
+
+// private BranchEvent methods used to check data before sending to network service.
+- (NSDictionary *)buildEventDictionary;
+- (BranchEventRequest *)buildRequestWithEventDictionary:(NSDictionary *)eventDictionary;
+
+@end
+
 @interface BranchEventTest : BNCTestCase
 @end
 
@@ -265,13 +273,429 @@
 }
 
 - (void)testStandardInviteEvent {
+    
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventInvite];
-    [event logEvent];
+    event.userID = @"test_userID@branch.io";
+    event.facebookUserID = @"test_facebook@branch.io";
+    event.googleUserID = @"test_google@branch.io";
+    event.twitterUserID = @"test_twitter@branch.io";
+
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"INVITE"]);
+    XCTAssertNil(eventDictionary[@"content_items"]);
+
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"userID"] isEqualToString:@"test_userID@branch.io"]);
+    XCTAssert([eventData[@"facebookUserID"] isEqualToString:@"test_facebook@branch.io"]);
+    XCTAssert([eventData[@"googleUserID"] isEqualToString:@"test_google@branch.io"]);
+    XCTAssert([eventData[@"twitterUserID"] isEqualToString:@"test_twitter@branch.io"]);
+    
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
 }
 
 - (void)testCustomInviteEvent {
+    
     BranchEvent *event = [BranchEvent customEventWithName:@"INVITE"];
-    [event logEvent];
+    event.userID = @"test_userID@branch.io";
+    event.facebookUserID = @"test_facebook@branch.io";
+    event.googleUserID = @"test_google@branch.io";
+    event.twitterUserID = @"test_twitter@branch.io";
+    
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"INVITE"]);
+    XCTAssertNotNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"userID"] isEqualToString:@"test_userID@branch.io"]);
+    XCTAssert([eventData[@"facebookUserID"] isEqualToString:@"test_facebook@branch.io"]);
+    XCTAssert([eventData[@"googleUserID"] isEqualToString:@"test_google@branch.io"]);
+    XCTAssert([eventData[@"twitterUserID"] isEqualToString:@"test_twitter@branch.io"]);
+ 
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+}
+
+- (void)testStandardLoginEvent {
+    
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventLogin];
+    event.userID = @"test_userID@branch.io";
+    event.facebookUserID = @"test_facebook@branch.io";
+    event.googleUserID = @"test_google@branch.io";
+    event.twitterUserID = @"test_twitter@branch.io";
+    event.userName = @"test_userName";
+    event.userEmail = @"test@branch.io";
+    event.latitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+    event.longitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+    event.altitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"LOGIN"]);
+    XCTAssertNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"userID"] isEqualToString:@"test_userID@branch.io"]);
+    XCTAssert([eventData[@"facebookUserID"] isEqualToString:@"test_facebook@branch.io"]);
+    XCTAssert([eventData[@"googleUserID"] isEqualToString:@"test_google@branch.io"]);
+    XCTAssert([eventData[@"twitterUserID"] isEqualToString:@"test_twitter@branch.io"]);
+    XCTAssert([eventData[@"latitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
+    XCTAssert([eventData[@"longitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
+    XCTAssert([eventData[@"altitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
+
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
+}
+
+- (void)testCustomLoginEvent {
+    
+    BranchEvent *event = [BranchEvent customEventWithName:@"LOGIN"];
+    event.userID = @"test_userID@branch.io";
+    event.facebookUserID = @"test_facebook@branch.io";
+    event.googleUserID = @"test_google@branch.io";
+    event.twitterUserID = @"test_twitter@branch.io";
+    event.userName = @"test_userName";
+    event.userEmail = @"test@branch.io";
+    event.latitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+    event.longitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+    event.altitude = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"LOGIN"]);
+    XCTAssertNotNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"userID"] isEqualToString:@"test_userID@branch.io"]);
+    XCTAssert([eventData[@"facebookUserID"] isEqualToString:@"test_facebook@branch.io"]);
+    XCTAssert([eventData[@"googleUserID"] isEqualToString:@"test_google@branch.io"]);
+    XCTAssert([eventData[@"twitterUserID"] isEqualToString:@"test_twitter@branch.io"]);
+    XCTAssert([eventData[@"latitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
+    XCTAssert([eventData[@"longitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
+    XCTAssert([eventData[@"altitude"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
+    
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+}
+
+- (void)testStandardReserveEvent {
+    
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventReserve];
+    
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"RESERVE"]);
+    XCTAssertNotNil(eventDictionary[@"content_items"]);
+    
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
+}
+
+- (void)testCustomReserveEvent {
+    
+    BranchEvent *event = [BranchEvent customEventWithName:@"RESERVE"];
+    
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"RESERVE"]);
+    XCTAssertNotNil(eventDictionary[@"content_items"]);
+    
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+}
+
+- (void)testStandardSubscribeEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventSubscribe];
+    event.currency = BNCCurrencyUSD;
+    event.revenue = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+    
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"SUBSCRIBE"]);
+    XCTAssertNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"currency"] isEqualToString:BNCCurrencyUSD]);
+    XCTAssert([eventData[@"revenue"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
+    
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
+}
+
+- (void)testCustomSubscribeEvent {
+    
+    BranchEvent *event = [BranchEvent customEventWithName:@"SUBSCRIBE"];
+    event.currency = BNCCurrencyUSD;
+    event.revenue = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+    
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"SUBSCRIBE"]);
+    XCTAssertNotNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"currency"] isEqualToString:BNCCurrencyUSD]);
+    XCTAssert([eventData[@"revenue"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
+    
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+}
+
+- (void)testStandardStartTrialEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventStartTrial];
+    event.currency = BNCCurrencyUSD;
+    event.revenue = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+    
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"START_TRIAL"]);
+    XCTAssertNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"currency"] isEqualToString:BNCCurrencyUSD]);
+    XCTAssert([eventData[@"revenue"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
+    
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
+}
+
+- (void)testCustomStartTrialEvent {
+    
+    BranchEvent *event = [BranchEvent customEventWithName:@"START_TRIAL"];
+    event.currency = BNCCurrencyUSD;
+    event.revenue = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+    
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"START_TRIAL"]);
+    XCTAssertNotNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"currency"] isEqualToString:BNCCurrencyUSD]);
+    XCTAssert([eventData[@"revenue"] isEqual:[NSDecimalNumber decimalNumberWithString:@"1.0"]]);
+    
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+}
+
+- (void)testStandardClickAdEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventClickAd];
+    event.adType = @(BranchEventAdTypeBanner);
+
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"CLICK_AD"]);
+    XCTAssertNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"adType"] isEqual:@(BranchEventAdTypeBanner)]);
+
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
+}
+
+- (void)testCustomClickAdEvent {
+    
+    BranchEvent *event = [BranchEvent customEventWithName:@"CLICK_AD"];
+    event.adType = @(BranchEventAdTypeBanner);
+    
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"CLICK_AD"]);
+    XCTAssertNotNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"adType"] isEqual:@(BranchEventAdTypeBanner)]);
+
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
+}
+
+- (void)testStandardViewAdEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventViewAd];
+    event.adType = @(BranchEventAdTypeBanner);
+    
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"VIEW_AD"]);
+    XCTAssertNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"adType"] isEqual:@(BranchEventAdTypeBanner)]);
+    
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
+}
+
+- (void)testCustomViewAdEvent {
+    
+    BranchEvent *event = [BranchEvent customEventWithName:@"VIEW_AD"];
+    event.adType = @(BranchEventAdTypeBanner);
+    
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.canonicalIdentifier = @"item/12345";
+    buo.canonicalUrl        = @"https://branch.io/deepviews";
+    buo.title               = @"My Content Title";
+    buo.contentDescription  = @"my_product_description1";
+    
+    NSMutableArray<BranchUniversalObject *> *contentItems = [NSMutableArray new];
+    [contentItems addObject:buo];
+    event.contentItems = contentItems;
+    
+    NSDictionary *eventDictionary = [event buildEventDictionary];
+    
+    XCTAssertNotNil(eventDictionary);
+    XCTAssert([eventDictionary[@"name"] isEqualToString:@"VIEW_AD"]);
+    XCTAssertNotNil(eventDictionary[@"content_items"]);
+    
+    NSDictionary *eventData = eventDictionary[@"event_data"];
+    XCTAssert([eventData[@"adType"] isEqual:@(BranchEventAdTypeBanner)]);
+    
+    BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
+    XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/custom"]);
 }
 
 @end

--- a/Branch-SDK-Tests/BranchEvent.Test.m
+++ b/Branch-SDK-Tests/BranchEvent.Test.m
@@ -194,9 +194,11 @@
         NSLog(@"URL: %@.", url);
         NSLog(@"Body: %@.", parameters);
 
-        if ([url containsString:@"branch.io/v2/event/standard"]) {
+        if ([url containsString:@"branch.io/v2/event/custom"]) {
             XCTAssertEqualObjects(expectedRequest, parameters);
             [expectation fulfill];
+        } else {
+            XCTFail(@"URL is unexpected. %@", url);
         }
     });
 
@@ -243,7 +245,8 @@
 
     // Set up and invoke --
     [branch clearNetworkQueue];
-    [buo userCompletedAction:BranchStandardEventPurchase];
+    [buo userCompletedAction:@"PURCHASE"];
+    
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
     [serverInterfaceMock stopMocking];
 }
@@ -258,6 +261,16 @@
     event.eventDescription = @"Product Search";
     event.searchQuery = @"product name";
     event.customData[@"rating"] = @"5";
+    [event logEvent];
+}
+
+- (void)testStandardInviteEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventInvite];
+    [event logEvent];
+}
+
+- (void)testCustomInviteEvent {
+    BranchEvent *event = [BranchEvent customEventWithName:@"INVITE"];
     [event logEvent];
 }
 

--- a/Branch-SDK-Tests/BranchEvent.Test.m
+++ b/Branch-SDK-Tests/BranchEvent.Test.m
@@ -292,7 +292,6 @@
     
     XCTAssertNotNil(eventDictionary);
     XCTAssert([eventDictionary[@"name"] isEqualToString:@"INVITE"]);
-    XCTAssertNil(eventDictionary[@"content_items"]);
 
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
@@ -339,7 +338,6 @@
     
     XCTAssertNotNil(eventDictionary);
     XCTAssert([eventDictionary[@"name"] isEqualToString:@"LOGIN"]);
-    XCTAssertNil(eventDictionary[@"content_items"]);
     
     BranchEventRequest *request = [event buildRequestWithEventDictionary:eventDictionary];
     XCTAssert([request.serverURL.absoluteString containsString:@"branch.io/v2/event/standard"]);
@@ -435,7 +433,6 @@
     
     XCTAssertNotNil(eventDictionary);
     XCTAssert([eventDictionary[@"name"] isEqualToString:@"SUBSCRIBE"]);
-    XCTAssertNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
     XCTAssert([eventData[@"currency"] isEqualToString:BNCCurrencyUSD]);
@@ -494,7 +491,6 @@
     
     XCTAssertNotNil(eventDictionary);
     XCTAssert([eventDictionary[@"name"] isEqualToString:@"START_TRIAL"]);
-    XCTAssertNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
     XCTAssert([eventData[@"currency"] isEqualToString:BNCCurrencyUSD]);
@@ -552,7 +548,6 @@
     
     XCTAssertNotNil(eventDictionary);
     XCTAssert([eventDictionary[@"name"] isEqualToString:@"CLICK_AD"]);
-    XCTAssertNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
     XCTAssert([eventData[@"ad_type"] isEqual:[event jsonStringForAdType:event.adType]]);
@@ -607,7 +602,6 @@
     
     XCTAssertNotNil(eventDictionary);
     XCTAssert([eventDictionary[@"name"] isEqualToString:@"VIEW_AD"]);
-    XCTAssertNil(eventDictionary[@"content_items"]);
     
     NSDictionary *eventData = eventDictionary[@"event_data"];
     XCTAssert([eventData[@"ad_type"] isEqual:[event jsonStringForAdType:event.adType]]);

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -511,10 +511,7 @@ static NSString * const BRANCH_PREFS_KEY_ANALYTICS_MANIFEST = @"bnc_branch_analy
 
 - (void)clearInstrumentationDictionary {
     @synchronized (self) {
-        NSArray *keys = [_instrumentationDictionary allKeys];
-        for (NSUInteger i = 0 ; i < [keys count]; i++) {
-            [_instrumentationDictionary removeObjectForKey:keys[i]];
-        }
+        [_instrumentationDictionary removeAllObjects];
     }
 }
 

--- a/Branch-SDK/Branch-SDK/BranchEvent.h
+++ b/Branch-SDK/Branch-SDK/BranchEvent.h
@@ -23,6 +23,10 @@ FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventInitiatePurcha
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventAddPaymentInfo;
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventPurchase;
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventSpendCredits;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventSubscribe;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventStartTrial;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventClickAd;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventViewAd;
 
 ///@name Content Events
 
@@ -38,16 +42,9 @@ FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventCompleteRegist
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventCompleteTutorial;
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventAchieveLevel;
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventUnlockAchievement;
-
-///@name TODO sort these events
-
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventInvite;
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventLogin;
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventReserve;
-FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventSubscribe;
-FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventStartTrial;
-FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventClickAd;
-FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventViewAd;
 
 typedef NS_ENUM(NSInteger, BranchEventAdType) {
     BranchEventAdTypeBanner,

--- a/Branch-SDK/Branch-SDK/BranchEvent.h
+++ b/Branch-SDK/Branch-SDK/BranchEvent.h
@@ -87,14 +87,11 @@ typedef NS_ENUM(NSInteger, BranchEventAdType) {
 @property (nonatomic, strong) NSString*_Nullable                facebookUserID;
 @property (nonatomic, strong) NSString*_Nullable                googleUserID;
 @property (nonatomic, strong) NSString*_Nullable                twitterUserID;
-
 @property (nonatomic, strong) NSString*_Nullable                userEmail;
 @property (nonatomic, strong) NSString*_Nullable                userName;
-
 @property (nonatomic, strong) NSDecimalNumber*_Nullable         latitude;
 @property (nonatomic, strong) NSDecimalNumber*_Nullable         longitude;
 @property (nonatomic, strong) NSDecimalNumber*_Nullable         altitude;
-
 @property (nonatomic, assign) NSNumber*_Nullable                adType;
 
 

--- a/Branch-SDK/Branch-SDK/BranchEvent.h
+++ b/Branch-SDK/Branch-SDK/BranchEvent.h
@@ -47,6 +47,7 @@ FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventLogin;
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventReserve;
 
 typedef NS_ENUM(NSInteger, BranchEventAdType) {
+    BranchEventAdTypeNone,
     BranchEventAdTypeBanner,
     BranchEventAdTypeInterstitial,
     BranchEventAdTypeRewardedVideo,
@@ -89,7 +90,7 @@ typedef NS_ENUM(NSInteger, BranchEventAdType) {
 @property (nonatomic, strong) NSDecimalNumber*_Nullable         latitude;
 @property (nonatomic, strong) NSDecimalNumber*_Nullable         longitude;
 @property (nonatomic, strong) NSDecimalNumber*_Nullable         altitude;
-@property (nonatomic, assign) NSNumber*_Nullable                adType;
+@property (nonatomic, assign) BranchEventAdType                 adType;
 
 
 @property (nonatomic, copy) NSMutableArray<BranchUniversalObject*>*_Nonnull       contentItems;

--- a/Branch-SDK/Branch-SDK/BranchEvent.h
+++ b/Branch-SDK/Branch-SDK/BranchEvent.h
@@ -39,6 +39,23 @@ FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventCompleteTutori
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventAchieveLevel;
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventUnlockAchievement;
 
+///@name TODO sort these events
+
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventInvite;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventLogin;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventReserve;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventSubscribe;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventStartTrial;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventClickAd;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventViewAd;
+
+typedef NS_ENUM(NSInteger, BranchEventAdType) {
+    BranchEventAdTypeBanner,
+    BranchEventAdTypeInterstitial,
+    BranchEventAdTypeRewardedVideo,
+    BranchEventAdTypeNative
+};
+
 #pragma mark - BranchEvent
 
 @interface BranchEvent : NSObject
@@ -65,6 +82,22 @@ FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventUnlockAchievem
 @property (nonatomic, strong) NSString*_Nullable                affiliation;
 @property (nonatomic, strong) NSString*_Nullable                eventDescription;
 @property (nonatomic, strong) NSString*_Nullable                searchQuery;
+
+@property (nonatomic, strong) NSString*_Nullable                userID;
+@property (nonatomic, strong) NSString*_Nullable                facebookUserID;
+@property (nonatomic, strong) NSString*_Nullable                googleUserID;
+@property (nonatomic, strong) NSString*_Nullable                twitterUserID;
+
+@property (nonatomic, strong) NSString*_Nullable                userEmail;
+@property (nonatomic, strong) NSString*_Nullable                userName;
+
+@property (nonatomic, strong) NSDecimalNumber*_Nullable         latitude;
+@property (nonatomic, strong) NSDecimalNumber*_Nullable         longitude;
+@property (nonatomic, strong) NSDecimalNumber*_Nullable         altitude;
+
+@property (nonatomic, assign) NSNumber*_Nullable                adType;
+
+
 @property (nonatomic, copy) NSMutableArray<BranchUniversalObject*>*_Nonnull       contentItems;
 @property (nonatomic, copy) NSMutableDictionary<NSString*, NSString*> *_Nonnull   customData;
 

--- a/Branch-SDK/Branch-SDK/BranchEvent.h
+++ b/Branch-SDK/Branch-SDK/BranchEvent.h
@@ -81,15 +81,6 @@ typedef NS_ENUM(NSInteger, BranchEventAdType) {
 @property (nonatomic, strong) NSString*_Nullable                eventDescription;
 @property (nonatomic, strong) NSString*_Nullable                searchQuery;
 
-@property (nonatomic, strong) NSString*_Nullable                userID;
-@property (nonatomic, strong) NSString*_Nullable                facebookUserID;
-@property (nonatomic, strong) NSString*_Nullable                googleUserID;
-@property (nonatomic, strong) NSString*_Nullable                twitterUserID;
-@property (nonatomic, strong) NSString*_Nullable                userEmail;
-@property (nonatomic, strong) NSString*_Nullable                userName;
-@property (nonatomic, strong) NSDecimalNumber*_Nullable         latitude;
-@property (nonatomic, strong) NSDecimalNumber*_Nullable         longitude;
-@property (nonatomic, strong) NSDecimalNumber*_Nullable         altitude;
 @property (nonatomic, assign) BranchEventAdType                 adType;
 
 

--- a/Branch-SDK/Branch-SDK/BranchEvent.m
+++ b/Branch-SDK/Branch-SDK/BranchEvent.m
@@ -255,23 +255,6 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
     ];
 }
 
-+ (NSArray<BranchStandardEvent> *)standardEventsWithoutBUO {
-    return @[BranchStandardEventInvite,
-             BranchStandardEventLogin,
-             BranchStandardEventSubscribe,
-             BranchStandardEventStartTrial,
-             BranchStandardEventClickAd,
-             BranchStandardEventViewAd];
-}
-
-// some standard events do not support the BUO
-- (BOOL)supportsBUO {
-    if (self.isStandardEvent && [[BranchEvent standardEventsWithoutBUO] containsObject:self.eventName]) {
-        return NO;
-    }
-    return YES;
-}
-
 - (void) logEvent {
 
     if (![_eventName isKindOfClass:[NSString class]] || _eventName.length == 0) {
@@ -312,18 +295,16 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
     eventDictionary[@"custom_data"] = eventDictionary[@"event_data"][@"custom_data"];
     eventDictionary[@"event_data"][@"custom_data"] = nil;
     
-    if ([self supportsBUO]) {
-        NSMutableArray *contentItemDictionaries = [NSMutableArray new];
-        for (BranchUniversalObject *contentItem in self.contentItems) {
-            NSDictionary *dictionary = [contentItem dictionary];
-            if (dictionary.count) {
-                [contentItemDictionaries addObject:dictionary];
-            }
+    NSMutableArray *contentItemDictionaries = [NSMutableArray new];
+    for (BranchUniversalObject *contentItem in self.contentItems) {
+        NSDictionary *dictionary = [contentItem dictionary];
+        if (dictionary.count) {
+            [contentItemDictionaries addObject:dictionary];
         }
-        
-        if (contentItemDictionaries.count) {
-            eventDictionary[@"content_items"] = contentItemDictionaries;
-        }
+    }
+    
+    if (contentItemDictionaries.count) {
+        eventDictionary[@"content_items"] = contentItemDictionaries;
     }
     return eventDictionary;
 }

--- a/Branch-SDK/Branch-SDK/BranchEvent.m
+++ b/Branch-SDK/Branch-SDK/BranchEvent.m
@@ -180,7 +180,6 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
     }
 }
 
-// Objective-C does not have string enums, convert for the server
 - (NSString *)jsonStringForAdType:(BranchEventAdType)adType {
     switch (adType) {
         case BranchEventAdTypeBanner:

--- a/Branch-SDK/Branch-SDK/BranchEvent.m
+++ b/Branch-SDK/Branch-SDK/BranchEvent.m
@@ -109,8 +109,6 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
 }
 @property (nonatomic, strong) NSString*  eventName;
 
-// standard events can have data enforcement rules and go to a different endpoint
-@property (nonatomic, assign) BOOL isStandardEvent;
 @end
 
 @implementation BranchEvent : NSObject
@@ -121,16 +119,11 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
     _eventName = name;
     
     _adType = BranchEventAdTypeNone;
-    _isStandardEvent = NO;
     return self;
 }
 
 + (instancetype) standardEvent:(BranchStandardEvent)standardEvent {
-    BranchEvent *event = [[BranchEvent alloc] initWithName:standardEvent];
-    if ([[BranchEvent standardEvents] containsObject:standardEvent]) {
-        event.isStandardEvent = YES;
-    }
-    return event;
+    return [[BranchEvent alloc] initWithName:standardEvent];
 }
 
 + (instancetype) standardEvent:(BranchStandardEvent)standardEvent
@@ -271,7 +264,7 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
     
     NSString *serverURL =
-    (self.isStandardEvent)
+    ([self.class.standardEvents containsObject:self.eventName])
     ? [NSString stringWithFormat:@"%@/%@", preferenceHelper.branchAPIURL, @"v2/event/standard"]
     : [NSString stringWithFormat:@"%@/%@", preferenceHelper.branchAPIURL, @"v2/event/custom"];
     

--- a/Branch-SDK/Branch-SDK/BranchEvent.m
+++ b/Branch-SDK/Branch-SDK/BranchEvent.m
@@ -119,6 +119,8 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
     self = [super init];
     if (!self) return self;
     _eventName = name;
+    
+    _adType = BranchEventAdTypeNone;
     _isStandardEvent = NO;
     return self;
 }
@@ -178,9 +180,30 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
     }
 }
 
+// Objective-C does not have string enums, convert for the server
+- (NSString *)jsonStringForAdType:(BranchEventAdType)adType {
+    switch (adType) {
+        case BranchEventAdTypeBanner:
+            return @"banner";
+            
+        case BranchEventAdTypeInterstitial:
+            return @"interstitial";
+            
+        case BranchEventAdTypeRewardedVideo:
+            return @"rewarded_video";
+            
+        case BranchEventAdTypeNative:
+            return @"native";
+            
+        case BranchEventAdTypeNone:
+        default:
+            return nil;
+    }
+}
+
 - (NSDictionary*) dictionary {
     NSMutableDictionary *dictionary = [NSMutableDictionary new];
-
+    
     #define BNCFieldDefinesDictionaryFromSelf
     #include "BNCFieldDefines.h"
 
@@ -194,19 +217,23 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
     addString(eventDescription, description);
     addString(searchQuery,      search_query)
     addDictionary(customData,   custom_data);
-    addString(userID,           userID);
-    addString(facebookUserID,   facebookUserID);
-    addString(googleUserID,     googleUserID);
-    addString(twitterUserID,    twitterUserID);
-    addString(userEmail,        userEmail);
-    addString(userName,         userName);
+    addString(userID,           user_id);
+    addString(facebookUserID,   facebook_user_id);
+    addString(googleUserID,     google_user_id);
+    addString(twitterUserID,    twitter_user_id);
+    addString(userEmail,        user_email);
+    addString(userName,         username);
     addDecimal(latitude,        latitude);
     addDecimal(longitude,       longitude);
     addDecimal(altitude,        altitude);
-    addNumber(adType,           adType);
     
     #include "BNCFieldDefines.h"
 
+    NSString *adTypeString = [self jsonStringForAdType:self.adType];
+    if (adTypeString.length > 0) {
+        [dictionary setObject:adTypeString forKey:@"ad_type"];
+    }
+    
     return dictionary;
 }
 

--- a/Branch-SDK/Branch-SDK/BranchEvent.m
+++ b/Branch-SDK/Branch-SDK/BranchEvent.m
@@ -183,16 +183,16 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
 - (NSString *)jsonStringForAdType:(BranchEventAdType)adType {
     switch (adType) {
         case BranchEventAdTypeBanner:
-            return @"banner";
+            return @"BANNER";
             
         case BranchEventAdTypeInterstitial:
-            return @"interstitial";
+            return @"INTERSTITIAL";
             
         case BranchEventAdTypeRewardedVideo:
-            return @"rewarded_video";
+            return @"REWARDED_VIDEO";
             
         case BranchEventAdTypeNative:
-            return @"native";
+            return @"NATIVE";
             
         case BranchEventAdTypeNone:
         default:
@@ -216,15 +216,6 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
     addString(eventDescription, description);
     addString(searchQuery,      search_query)
     addDictionary(customData,   custom_data);
-    addString(userID,           user_id);
-    addString(facebookUserID,   facebook_user_id);
-    addString(googleUserID,     google_user_id);
-    addString(twitterUserID,    twitter_user_id);
-    addString(userEmail,        user_email);
-    addString(userName,         username);
-    addDecimal(latitude,        latitude);
-    addDecimal(longitude,       longitude);
-    addDecimal(altitude,        altitude);
     
     #include "BNCFieldDefines.h"
 

--- a/Branch-SDK/Branch-SDK/BranchEvent.m
+++ b/Branch-SDK/Branch-SDK/BranchEvent.m
@@ -36,6 +36,16 @@ BranchStandardEvent BranchStandardEventCompleteTutorial       = @"COMPLETE_TUTOR
 BranchStandardEvent BranchStandardEventAchieveLevel           = @"ACHIEVE_LEVEL";
 BranchStandardEvent BranchStandardEventUnlockAchievement      = @"UNLOCK_ACHIEVEMENT";
 
+// TODO: move these new events to appropriate sections
+
+BranchStandardEvent BranchStandardEventInvite = @"INVITE";
+BranchStandardEvent BranchStandardEventLogin = @"LOGIN";
+BranchStandardEvent BranchStandardEventReserve = @"RESERVE";
+BranchStandardEvent BranchStandardEventSubscribe = @"SUBSCRIBE";
+BranchStandardEvent BranchStandardEventStartTrial = @"START_TRIAL";
+BranchStandardEvent BranchStandardEventClickAd = @"CLICK_AD";
+BranchStandardEvent BranchStandardEventViewAd = @"VIEW_AD";
+
 @implementation BranchEventRequest
 
 - (instancetype) initWithServerURL:(NSURL*)serverURL
@@ -153,6 +163,8 @@ BranchStandardEvent BranchStandardEventUnlockAchievement      = @"UNLOCK_ACHIEVE
 }
 
 - (void) setContentItems:(NSMutableArray<BranchUniversalObject *> *)contentItems {
+    
+    
     if ([contentItems isKindOfClass:[BranchUniversalObject class]]) {
         _contentItems = [NSMutableArray arrayWithObject:contentItems];
     } else
@@ -178,6 +190,19 @@ BranchStandardEvent BranchStandardEventUnlockAchievement      = @"UNLOCK_ACHIEVE
     addString(searchQuery,      search_query)
     addDictionary(customData,   custom_data);
     
+    addString(userID, userID);
+    addString(facebookUserID, facebookUserID);
+    addString(googleUserID, googleUserID);
+    addString(twitterUserID, twitterUserID);
+    
+    addString(userEmail, userEmail);
+    addString(userName, userName);
+    addDecimal(latitude, latitude);
+    addDecimal(longitude, longitude);
+    addDecimal(altitude, altitude);
+    
+    addNumber(adType, adType);
+    
     #include "BNCFieldDefines.h"
 
     return dictionary;
@@ -201,7 +226,26 @@ BranchStandardEvent BranchStandardEventUnlockAchievement      = @"UNLOCK_ACHIEVE
         BranchStandardEventCompleteTutorial,
         BranchStandardEventAchieveLevel,
         BranchStandardEventUnlockAchievement,
+        BranchStandardEventInvite,
+        BranchStandardEventLogin,
+        BranchStandardEventReserve,
+        BranchStandardEventSubscribe,
+        BranchStandardEventStartTrial,
+        BranchStandardEventClickAd,
+        BranchStandardEventViewAd,
     ];
+}
+
+// Do we want to do validation?  I think the server should drop invalid data instead of validating here.
+// Otherwise, it makes sense to validate all the standard events here.
++ (NSArray<BranchStandardEvent> *)standardEventsWithoutBUO {
+    return @[BranchStandardEventInvite,
+             BranchStandardEventLogin,
+             BranchStandardEventSubscribe,
+             BranchStandardEventStartTrial,
+             BranchStandardEventClickAd,
+             BranchStandardEventViewAd,
+             ];
 }
 
 - (void) logEvent {

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -425,6 +425,13 @@ static NSString *type = @"some type";
         ,BranchStandardEventCompleteTutorial
         ,BranchStandardEventAchieveLevel
         ,BranchStandardEventUnlockAchievement
+        ,BranchStandardEventInvite
+        ,BranchStandardEventLogin
+        ,BranchStandardEventReserve
+        ,BranchStandardEventSubscribe
+        ,BranchStandardEventStartTrial
+        ,BranchStandardEventClickAd
+        ,BranchStandardEventViewAd
         ,@"iOS-CustomEvent"
 
     ];
@@ -496,6 +503,20 @@ static NSString *type = @"some type";
         @"Custom_Event_Property_Key2": @"Custom_Event_Property_val2"
     };
     event.contentItems = (id) @[ buo ];
+    
+    event.userID = @"echo@branch.io";
+    event.facebookUserID = @"echo@branch.io";
+    event.googleUserID = @"echo@branch.io";
+    event.twitterUserID = @"echo@branch.io";
+    
+    event.userEmail = @"echo@branch.io";
+    event.userName = @"echo@branch.io";
+    event.latitude = [NSDecimalNumber decimalNumberWithString:@"47.6062"];
+    event.longitude = [NSDecimalNumber decimalNumberWithString:@"-122.3321"];
+    event.altitude = [NSDecimalNumber decimalNumberWithString:@"10.0"];
+    
+    event.adType = @(BranchEventAdTypeBanner);
+    
     [event logEvent];
 }
 

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -31,6 +31,10 @@ static NSString *live_key = @"live_key";
 static NSString *test_key = @"test_key";
 static NSString *type = @"some type";
 
+@interface BranchEvent()
++ (NSArray<BranchStandardEvent>*) standardEvents;
+@end
+
 @interface ViewController () <BranchShareLinkDelegate> {
     NSDateFormatter *_dateFormatter;
 }
@@ -447,7 +451,90 @@ static NSString *type = @"some type";
     }];
 }
 
-- (void) sendV2EventWithName:(NSString*)eventName {
+- (void)sendV2EventWithName:(NSString *)eventName {
+
+    // standard events with data requirements
+    if ([eventName isEqualToString:BranchStandardEventInvite]) {
+        [self sendInviteEvent];
+    } else if ([eventName isEqualToString:BranchStandardEventLogin]) {
+        [self sendLoginEvent];
+    } else if ([eventName isEqualToString:BranchStandardEventSubscribe]) {
+        [self sendSubscribeEvent];
+    } else if ([eventName isEqualToString:BranchStandardEventStartTrial]) {
+        [self sendStartTrialEvent];
+    } else if ([eventName isEqualToString:BranchStandardEventClickAd]) {
+        [self sendClickAdEvent];
+    } else if ([eventName isEqualToString:BranchStandardEventViewAd]) {
+        [self sendViewAdEvent];
+        
+    // other standard events
+    } else if ([[BranchEvent standardEvents] containsObject:eventName]) {
+        [self sendStandardV2Event:eventName];
+        
+    // custom events
+    } else {
+        [self sendCustomV2Event:eventName];
+    }
+}
+
+- (void)sendInviteEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventInvite];
+    event.userID = @"test_userID@branch.io";
+    event.facebookUserID = @"test_facebook@branch.io";
+    event.googleUserID = @"test_google@branch.io";
+    event.twitterUserID = @"test_twitter@branch.io";
+    [event logEvent];
+}
+
+- (void)sendLoginEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventLogin];
+    event.userID = @"test_userID@branch.io";
+    event.facebookUserID = @"test_facebook@branch.io";
+    event.googleUserID = @"test_google@branch.io";
+    event.twitterUserID = @"test_twitter@branch.io";
+    event.userName = @"test_userName";
+    event.userEmail = @"test@branch.io";
+    event.latitude = [NSDecimalNumber decimalNumberWithString:@"47.6062"];
+    event.longitude = [NSDecimalNumber decimalNumberWithString:@"-122.3321"];
+    event.altitude = [NSDecimalNumber decimalNumberWithString:@"148.0"];
+    [event logEvent];
+}
+
+- (void)sendSubscribeEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventSubscribe];
+    event.currency = BNCCurrencyUSD;
+    event.revenue = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+    [event logEvent];
+}
+
+- (void)sendStartTrialEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventStartTrial];
+    event.currency = BNCCurrencyUSD;
+    event.revenue = [NSDecimalNumber decimalNumberWithString:@"1.0"];
+    [event logEvent];
+}
+
+- (void)sendClickAdEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventClickAd];
+    event.adType = @(BranchEventAdTypeBanner);
+    [event logEvent];
+}
+
+- (void)sendViewAdEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventClickAd];
+    event.adType = @(BranchEventAdTypeBanner);
+    [event logEvent];
+}
+
+- (void)sendStandardV2Event:(BranchStandardEvent)event {
+    [self sendGenericV2EventWithName:event isStandardEvent:YES];
+}
+
+- (void)sendCustomV2Event:(NSString *)eventName {
+    [self sendGenericV2EventWithName:eventName isStandardEvent:NO];
+}
+
+- (void) sendGenericV2EventWithName:(NSString*)eventName isStandardEvent:(BOOL)isStandardEvent {
     BranchUniversalObject *buo = [BranchUniversalObject new];
 
     buo.contentMetadata.contentSchema    = BranchContentSchemaCommerceProduct;
@@ -489,7 +576,12 @@ static NSString *type = @"some type";
     buo.locallyIndex                = YES;
     buo.creationDate                = [NSDate date];
 
-    BranchEvent *event    = [BranchEvent customEventWithName:eventName];
+    BranchEvent *event;
+    if (isStandardEvent) {
+        event = [BranchEvent standardEvent:eventName];
+    } else {
+        event = [BranchEvent customEventWithName:eventName];
+    }
     event.transactionID   = @"12344555";
     event.currency        = BNCCurrencyUSD;
     event.revenue         = [NSDecimalNumber decimalNumberWithString:@"1.5"];
@@ -503,19 +595,6 @@ static NSString *type = @"some type";
         @"Custom_Event_Property_Key2": @"Custom_Event_Property_val2"
     };
     event.contentItems = (id) @[ buo ];
-    
-//    event.userID = @"echo@branch.io";
-//    event.facebookUserID = @"echo@branch.io";
-//    event.googleUserID = @"echo@branch.io";
-//    event.twitterUserID = @"echo@branch.io";
-//
-//    event.userEmail = @"echo@branch.io";
-//    event.userName = @"echo@branch.io";
-//    event.latitude = [NSDecimalNumber decimalNumberWithString:@"47.6062"];
-//    event.longitude = [NSDecimalNumber decimalNumberWithString:@"-122.3321"];
-//    event.altitude = [NSDecimalNumber decimalNumberWithString:@"10.0"];
-//
-//    event.adType = @(BranchEventAdTypeBanner);
     
     [event logEvent];
 }

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -504,18 +504,18 @@ static NSString *type = @"some type";
     };
     event.contentItems = (id) @[ buo ];
     
-    event.userID = @"echo@branch.io";
-    event.facebookUserID = @"echo@branch.io";
-    event.googleUserID = @"echo@branch.io";
-    event.twitterUserID = @"echo@branch.io";
-    
-    event.userEmail = @"echo@branch.io";
-    event.userName = @"echo@branch.io";
-    event.latitude = [NSDecimalNumber decimalNumberWithString:@"47.6062"];
-    event.longitude = [NSDecimalNumber decimalNumberWithString:@"-122.3321"];
-    event.altitude = [NSDecimalNumber decimalNumberWithString:@"10.0"];
-    
-    event.adType = @(BranchEventAdTypeBanner);
+//    event.userID = @"echo@branch.io";
+//    event.facebookUserID = @"echo@branch.io";
+//    event.googleUserID = @"echo@branch.io";
+//    event.twitterUserID = @"echo@branch.io";
+//
+//    event.userEmail = @"echo@branch.io";
+//    event.userName = @"echo@branch.io";
+//    event.latitude = [NSDecimalNumber decimalNumberWithString:@"47.6062"];
+//    event.longitude = [NSDecimalNumber decimalNumberWithString:@"-122.3321"];
+//    event.altitude = [NSDecimalNumber decimalNumberWithString:@"10.0"];
+//
+//    event.adType = @(BranchEventAdTypeBanner);
     
     [event logEvent];
 }

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -479,24 +479,11 @@ static NSString *type = @"some type";
 
 - (void)sendInviteEvent {
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventInvite];
-    event.userID = @"test_userID@branch.io";
-    event.facebookUserID = @"test_facebook@branch.io";
-    event.googleUserID = @"test_google@branch.io";
-    event.twitterUserID = @"test_twitter@branch.io";
     [event logEvent];
 }
 
 - (void)sendLoginEvent {
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventLogin];
-    event.userID = @"test_userID@branch.io";
-    event.facebookUserID = @"test_facebook@branch.io";
-    event.googleUserID = @"test_google@branch.io";
-    event.twitterUserID = @"test_twitter@branch.io";
-    event.userName = @"test_userName";
-    event.userEmail = @"test@branch.io";
-    event.latitude = [NSDecimalNumber decimalNumberWithString:@"47.6062"];
-    event.longitude = [NSDecimalNumber decimalNumberWithString:@"-122.3321"];
-    event.altitude = [NSDecimalNumber decimalNumberWithString:@"148.0"];
     [event logEvent];
 }
 
@@ -516,13 +503,13 @@ static NSString *type = @"some type";
 
 - (void)sendClickAdEvent {
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventClickAd];
-    event.adType = @(BranchEventAdTypeBanner);
+    event.adType = BranchEventAdTypeBanner;
     [event logEvent];
 }
 
 - (void)sendViewAdEvent {
     BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventClickAd];
-    event.adType = @(BranchEventAdTypeBanner);
+    event.adType = BranchEventAdTypeBanner;
     [event logEvent];
 }
 


### PR DESCRIPTION
**Changes due to updated spec**

1. Ad type constants are now CAPS  
2. BUO is sent
3. All events are routed through the same logic.  There is no difference between the custom and standard API.  This is how the current implementation works.

**Old description:**

These are new standard events for FB and Tune.  Most of these new standard events do NOT support the BranchUniversalObject.  Only RESERVE supports the BUO.

Also there is a behavior change.  Previously standard events created via the customEvent API would go to the standard server endpoint.  Now all events created via the customEvent API will go to the custom server endpoint.

All events created via BranchUniversalObject's userCompletedAction are treated as custom events.
