### PR TITLE
SDK-76 nsexception in setBranchKey

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -225,8 +225,23 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  You can only set the Branch key once per app run.
 
  @param branchKey The Branch key to use.
+ @param error NSError will be set if Branch encounters a key error.
 */
++ (void) setBranchKey:(NSString*)branchKey error:(NSError **)error;
+
+/**
+ Directly sets the Branch key to be used.  Branch usually reads the Branch key from your app's
+ Info.plist file which is recommended and more convenient.  But the Branch key can also be set
+ with this method. See the documentation at
+ https://dev.branch.io/getting-started/sdk-integration-guide/guide/ios/#configure-xcode-project
+ for information about configuring your app with Branch keys.
+ 
+ You can only set the Branch key once per app run.  Any errors are logged.
+ 
+ @param branchKey The Branch key to use.
+ */
 + (void) setBranchKey:(NSString*)branchKey;
+
 
 /// @return Returns the current Branch key.
 + (NSString*) branchKey;

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -392,7 +392,6 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
 
         if ([branchKey hasPrefix:@"key_test"]) {
             bnc_useTestBranchKey = YES;
-            // Consider making this an NSError?  It's not really an error but users need to be aware they're using a test key.
             BNCLogWarning(
                 @"You are using your test app's Branch Key. "
                  "Remember to change it to live Branch Key for production deployment."

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -339,6 +339,10 @@ static BOOL bnc_useTestBranchKey = NO;
 static NSString *bnc_branchKey = nil;
 static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
 
++ (void) resetBranchKey {
+    bnc_branchKey = nil;
+}
+
 + (void) setUseTestBranchKey:(BOOL)useTestKey {
     @synchronized (self) {
         if (bnc_branchKey && !!useTestKey != !!bnc_useTestBranchKey) {
@@ -355,7 +359,16 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
     }
 }
 
-+ (void) setBranchKey:(NSString*)branchKey {
++ (void)setBranchKey:(NSString *)branchKey {
+    NSError *error;
+    [self setBranchKey:branchKey error:&error];
+    
+    if (error) {
+        BNCLogError(@"Branch init error: %@", error.localizedDescription);
+    }
+}
+
++ (void)setBranchKey:(NSString*)branchKey error:(NSError **)error {
     @synchronized (self) {
         if (bnc_branchKey) {
             if (branchKey &&
@@ -363,28 +376,34 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
                 [branchKey isEqualToString:bnc_branchKey]) {
                 return;
             }
-            BNCLogError(@"Branch key can only be set once.");
+            
+            NSString *errorMessage = [NSString stringWithFormat:@"Branch key can only be set once."];
+            *error = [NSError branchErrorWithCode:BNCInitError localizedMessage:errorMessage];
             return;
         }
+        
         if (![branchKey isKindOfClass:[NSString class]]) {
             NSString *typeName = (branchKey) ? NSStringFromClass(branchKey.class) : @"<nil>";
-            [NSException raise:NSInternalInconsistencyException
-                format:@"Invalid Branch key of type '%@'.", typeName];
+            
+            NSString *errorMessage = [NSString stringWithFormat:@"Invalid Branch key of type '%@'.", typeName];
+            *error = [NSError branchErrorWithCode:BNCInitError localizedMessage:errorMessage];
             return;
         }
 
         if ([branchKey hasPrefix:@"key_test"]) {
             bnc_useTestBranchKey = YES;
+            // Consider making this an NSError?  It's not really an error but users need to be aware they're using a test key.
             BNCLogWarning(
                 @"You are using your test app's Branch Key. "
                  "Remember to change it to live Branch Key for production deployment."
             );
-        } else
-        if ([branchKey hasPrefix:@"key_live"]) {
+        
+        } else if ([branchKey hasPrefix:@"key_live"]) {
             bnc_useTestBranchKey = NO;
+        
         } else {
-            [NSException raise:NSInternalInconsistencyException
-                format:@"Invalid Branch key format. Did you add your Branch key to your Info.plist? Passed key is '%@'.", branchKey];
+            NSString *errorMessage = [NSString stringWithFormat:@"Invalid Branch key format. Did you add your Branch key to your Info.plist? Passed key is '%@'.", branchKey];
+            *error = [NSError branchErrorWithCode:BNCInitError localizedMessage:errorMessage];
             return;
         }
 

--- a/Branch-TestBed/Branch-SDK-Unhosted-Tests/Branch_setBranchKeyTests.m
+++ b/Branch-TestBed/Branch-SDK-Unhosted-Tests/Branch_setBranchKeyTests.m
@@ -9,9 +9,12 @@
 #import <XCTest/XCTest.h>
 #import "Branch.h"
 
-/**
- Tests pre-init methods.  These must run unhosted in order to avoid initialization that the test app does.
- */
+// expose private methods used by tests
+@interface Branch()
++ (void) resetBranchKey;
+@end
+
+// Tests pre-init methods.  These run unhosted in order to avoid initialization that the test app does.
 @interface Branch_setBranchKeyTests : XCTestCase
 
 @end
@@ -19,7 +22,7 @@
 @implementation Branch_setBranchKeyTests
 
 - (void)setUp {
-
+    [Branch resetBranchKey];
 }
 
 - (void)tearDown {
@@ -27,15 +30,70 @@
 }
 
 - (void)testSetBranchKey_validKey {
-    XCTAssertNoThrow([Branch setBranchKey:@"key_live_foo"]);
+    NSString *testKey = @"key_live_foo";
+    
+    // previous implementation would throw exceptions on misconfiguration, this is deprecated behavior.
+    XCTAssertNoThrow([Branch setBranchKey:testKey]);
+    XCTAssert([[Branch branchKey] isEqualToString:testKey]);
 }
 
 - (void)testSetBranchKey_nilKey {
-    XCTAssertNoThrow([Branch setBranchKey:nil]);
+    NSString *testKey = nil;
+    
+    // previous implementation would throw exceptions on misconfiguration, this is deprecated behavior.
+    XCTAssertNoThrow([Branch setBranchKey:testKey]);
+    XCTAssert([Branch branchKey] == nil);
 }
 
 - (void)testSetBranchKey_invalidKey {
-    XCTAssertNoThrow([Branch setBranchKey:@"invalid_key"]);
+    NSString *testKey = @"invalid_key";
+    
+    // previous implementation would throw exceptions on misconfiguration, this is deprecated behavior.
+    XCTAssertNoThrow([Branch setBranchKey:testKey]);
+    XCTAssert([Branch branchKey] == nil);
+}
+
+- (void)testSetBranchKeyWithError_validKey {
+    NSString *testKey = @"key_live_foo";
+    
+    NSError *error = nil;
+    [Branch setBranchKey:testKey error:&error];
+    XCTAssertNil(error);
+    
+    XCTAssert([[Branch branchKey] isEqualToString:testKey]);
+}
+
+- (void)testSetBranchKeyWithError_nilKey {
+    NSError *error = nil;
+    [Branch setBranchKey:nil error:&error];
+    XCTAssertNotNil(error);
+    
+    XCTAssert([error.localizedFailureReason isEqualToString:@"Invalid Branch key of type '<nil>'."]);
+    XCTAssert([Branch branchKey] == nil);
+}
+
+- (void)testSetBranchKeyWithError_invalidKey {
+    NSError *error = nil;
+    [Branch setBranchKey:@"invalid_key" error:&error];
+    XCTAssertNotNil(error);
+    
+    XCTAssert([error.localizedFailureReason isEqualToString:@"Invalid Branch key format. Did you add your Branch key to your Info.plist? Passed key is 'invalid_key'."]);
+    XCTAssert([Branch branchKey] == nil);
+}
+
+- (void)testSetBranchKeyWithError_validKeyTwice {
+    NSString *testKey = @"key_live_foo";
+    
+    NSError *error = nil;
+    [Branch setBranchKey:testKey error:&error];
+    XCTAssertNil(error);
+    XCTAssert([[Branch branchKey] isEqualToString:testKey]);
+
+    // Cannot change the key after it is set once
+    [Branch setBranchKey:@"key_live_bar" error:&error];
+    XCTAssertNotNil(error);
+    XCTAssert([error.localizedFailureReason isEqualToString:@"Branch key can only be set once."]);
+    XCTAssert([[Branch branchKey] isEqualToString:testKey]);
 }
 
 @end

--- a/Branch-TestBed/Branch-SDK-Unhosted-Tests/Branch_setBranchKeyTests.m
+++ b/Branch-TestBed/Branch-SDK-Unhosted-Tests/Branch_setBranchKeyTests.m
@@ -1,0 +1,41 @@
+//
+//  Branch_setBranchKeyTests.m
+//  Branch-SDK-Unhosted-Tests
+//
+//  Created by Ernest Cho on 12/3/18.
+//  Copyright © 2018 Branch, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "Branch.h"
+
+/**
+ Tests pre-init methods.  These must run unhosted in order to avoid initialization that the test app does.
+ */
+@interface Branch_setBranchKeyTests : XCTestCase
+
+@end
+
+@implementation Branch_setBranchKeyTests
+
+- (void)setUp {
+
+}
+
+- (void)tearDown {
+
+}
+
+- (void)testSetBranchKey_validKey {
+    XCTAssertNoThrow([Branch setBranchKey:@"key_live_foo"]);
+}
+
+- (void)testSetBranchKey_nilKey {
+    XCTAssertNoThrow([Branch setBranchKey:nil]);
+}
+
+- (void)testSetBranchKey_invalidKey {
+    XCTAssertNoThrow([Branch setBranchKey:@"invalid_key"]);
+}
+
+@end

--- a/Branch-TestBed/Branch-SDK-Unhosted-Tests/Info.plist
+++ b/Branch-TestBed/Branch-SDK-Unhosted-Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -166,6 +166,8 @@
 		54391A161BA249FA0061CB0F /* BranchCSSearchableItemAttributeSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 54391A141BA249FA0061CB0F /* BranchCSSearchableItemAttributeSet.m */; };
 		54FF1F8E1BD1D4AE0004CE2E /* BranchUniversalObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FF1F8C1BD1D4AE0004CE2E /* BranchUniversalObject.m */; };
 		54FF1F921BD1DC320004CE2E /* BranchLinkProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FF1F901BD1DC320004CE2E /* BranchLinkProperties.m */; };
+		5F8B7B4021B5F5CD009CE0A6 /* libBranch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 466B58381B17773000A69EDE /* libBranch.a */; };
+		5F8B7B4721B5F5F0009CE0A6 /* Branch_setBranchKeyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F8B7B4621B5F5F0009CE0A6 /* Branch_setBranchKeyTests.m */; };
 		63E4C4881D25E16A00A45FD8 /* LogOutputViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 63E4C4871D25E16A00A45FD8 /* LogOutputViewController.m */; };
 		63E4C48B1D25E17B00A45FD8 /* NavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 63E4C48A1D25E17B00A45FD8 /* NavigationController.m */; };
 		63E4C4901D25E1BC00A45FD8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63E4C48F1D25E1BC00A45FD8 /* LaunchScreen.storyboard */; };
@@ -220,6 +222,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 6700165F1940F51400A9E103;
 			remoteInfo = "Branch-TestBed";
+		};
+		5F8B7B4121B5F5CD009CE0A6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 670016581940F51400A9E103 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 466B58371B17773000A69EDE;
+			remoteInfo = Branch;
 		};
 		F1D4F9B11F323F01002D13FF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -379,6 +388,9 @@
 		54FF1F8C1BD1D4AE0004CE2E /* BranchUniversalObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchUniversalObject.m; sourceTree = "<group>"; };
 		54FF1F8F1BD1DC320004CE2E /* BranchLinkProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchLinkProperties.h; sourceTree = "<group>"; };
 		54FF1F901BD1DC320004CE2E /* BranchLinkProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchLinkProperties.m; sourceTree = "<group>"; };
+		5F8B7B3B21B5F5CD009CE0A6 /* Branch-SDK-Unhosted-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Branch-SDK-Unhosted-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5F8B7B3F21B5F5CD009CE0A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5F8B7B4621B5F5F0009CE0A6 /* Branch_setBranchKeyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Branch_setBranchKeyTests.m; sourceTree = "<group>"; };
 		63E4C4861D25E16A00A45FD8 /* LogOutputViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LogOutputViewController.h; sourceTree = "<group>"; };
 		63E4C4871D25E16A00A45FD8 /* LogOutputViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LogOutputViewController.m; sourceTree = "<group>"; };
 		63E4C4891D25E17B00A45FD8 /* NavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NavigationController.h; sourceTree = "<group>"; };
@@ -466,6 +478,14 @@
 				4D698B7D1FB287A700AFF38C /* SafariServices.framework in Frameworks */,
 				4D1851C120180F3300E48994 /* Security.framework in Frameworks */,
 				466B58531B17776A00A69EDE /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5F8B7B3821B5F5CD009CE0A6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5F8B7B4021B5F5CD009CE0A6 /* libBranch.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -624,6 +644,15 @@
 			path = "Branch-TestBed-UITests";
 			sourceTree = "<group>";
 		};
+		5F8B7B3C21B5F5CD009CE0A6 /* Branch-SDK-Unhosted-Tests */ = {
+			isa = PBXGroup;
+			children = (
+				5F8B7B4621B5F5F0009CE0A6 /* Branch_setBranchKeyTests.m */,
+				5F8B7B3F21B5F5CD009CE0A6 /* Info.plist */,
+			);
+			path = "Branch-SDK-Unhosted-Tests";
+			sourceTree = "<group>";
+		};
 		670016571940F51400A9E103 = {
 			isa = PBXGroup;
 			children = (
@@ -631,6 +660,7 @@
 				670016BB1946309100A9E103 /* Branch-SDK */,
 				4D16837A2098C901008819E3 /* Branch-SDK-Tests */,
 				670016691940F51400A9E103 /* Branch-TestBed */,
+				5F8B7B3C21B5F5CD009CE0A6 /* Branch-SDK-Unhosted-Tests */,
 				4D93D85E2098D43C00CFABA6 /* Branch-TestBed-UITests */,
 				E220F4281C7D39D500F5B126 /* Fabric */,
 				670016621940F51400A9E103 /* Frameworks */,
@@ -646,6 +676,7 @@
 				7E6B3B511AA42D0E005F45BF /* Branch-SDK-Tests.xctest */,
 				466B58381B17773000A69EDE /* libBranch.a */,
 				F1D4F9AC1F323F01002D13FF /* Branch-TestBed-UITests.xctest */,
+				5F8B7B3B21B5F5CD009CE0A6 /* Branch-SDK-Unhosted-Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -911,6 +942,24 @@
 			productReference = 466B58381B17773000A69EDE /* libBranch.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		5F8B7B3A21B5F5CD009CE0A6 /* Branch-SDK-Unhosted-Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5F8B7B4521B5F5CD009CE0A6 /* Build configuration list for PBXNativeTarget "Branch-SDK-Unhosted-Tests" */;
+			buildPhases = (
+				5F8B7B3721B5F5CD009CE0A6 /* Sources */,
+				5F8B7B3821B5F5CD009CE0A6 /* Frameworks */,
+				5F8B7B3921B5F5CD009CE0A6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5F8B7B4221B5F5CD009CE0A6 /* PBXTargetDependency */,
+			);
+			name = "Branch-SDK-Unhosted-Tests";
+			productName = "Branch-SDK-Unhosted-Tests";
+			productReference = 5F8B7B3B21B5F5CD009CE0A6 /* Branch-SDK-Unhosted-Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		6700165F1940F51400A9E103 /* Branch-TestBed */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 670016921940F51400A9E103 /* Build configuration list for PBXNativeTarget "Branch-TestBed" */;
@@ -981,6 +1030,11 @@
 					466B58371B17773000A69EDE = {
 						CreatedOnToolsVersion = 6.3.2;
 					};
+					5F8B7B3A21B5F5CD009CE0A6 = {
+						CreatedOnToolsVersion = 10.1;
+						DevelopmentTeam = R63EM248DP;
+						ProvisioningStyle = Automatic;
+					};
 					6700165F1940F51400A9E103 = {
 						DevelopmentTeam = R63EM248DP;
 						SystemCapabilities = {
@@ -1022,12 +1076,20 @@
 				466B58371B17773000A69EDE /* Branch */,
 				6700165F1940F51400A9E103 /* Branch-TestBed */,
 				7E6B3B501AA42D0E005F45BF /* Branch-SDK-Tests */,
+				5F8B7B3A21B5F5CD009CE0A6 /* Branch-SDK-Unhosted-Tests */,
 				F1D4F9AB1F323F01002D13FF /* Branch-TestBed-UITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		5F8B7B3921B5F5CD009CE0A6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6700165E1940F51400A9E103 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1145,6 +1207,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5F8B7B3721B5F5CD009CE0A6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5F8B7B4721B5F5F0009CE0A6 /* Branch_setBranchKeyTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6700165C1940F51400A9E103 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1229,6 +1299,11 @@
 			target = 6700165F1940F51400A9E103 /* Branch-TestBed */;
 			targetProxy = 4D337DDC201019B8009A5774 /* PBXContainerItemProxy */;
 		};
+		5F8B7B4221B5F5CD009CE0A6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 466B58371B17773000A69EDE /* Branch */;
+			targetProxy = 5F8B7B4121B5F5CD009CE0A6 /* PBXContainerItemProxy */;
+		};
 		F1D4F9B21F323F01002D13FF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 6700165F1940F51400A9E103 /* Branch-TestBed */;
@@ -1284,6 +1359,51 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = /headers;
 				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		5F8B7B4321B5F5CD009CE0A6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = R63EM248DP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Branch-SDK-Unhosted-Tests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.Branch-SDK-Unhosted-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		5F8B7B4421B5F5CD009CE0A6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = R63EM248DP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Branch-SDK-Unhosted-Tests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.Branch-SDK-Unhosted-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -1417,7 +1537,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.sdk.Branch-TestBed";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				USER_HEADER_SEARCH_PATHS = "$PROJECT_DIR";
+				USER_HEADER_SEARCH_PATHS = $PROJECT_DIR;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1438,7 +1558,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.sdk.Branch-TestBed";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				USER_HEADER_SEARCH_PATHS = "$PROJECT_DIR";
+				USER_HEADER_SEARCH_PATHS = $PROJECT_DIR;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -1531,6 +1651,15 @@
 			buildConfigurations = (
 				466B58491B17773000A69EDE /* Debug */,
 				466B584A1B17773000A69EDE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5F8B7B4521B5F5CD009CE0A6 /* Build configuration list for PBXNativeTarget "Branch-SDK-Unhosted-Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5F8B7B4321B5F5CD009CE0A6 /* Debug */,
+				5F8B7B4421B5F5CD009CE0A6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/xcshareddata/xcschemes/Branch-SDK-Unhosted-Tests.xcscheme
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/xcshareddata/xcschemes/Branch-SDK-Unhosted-Tests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5F8B7B3A21B5F5CD009CE0A6"
+               BuildableName = "Branch-SDK-Unhosted-Tests.xctest"
+               BlueprintName = "Branch-SDK-Unhosted-Tests"
+               ReferencedContainer = "container:Branch-TestBed.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
**Replace NSException with NSError in setBranchKey.**

Remove NSException use. This fixes the crash on misconfiguration.

Add an NSError out parameter. This allows runtime handling of branch initialization errors. Technically, they could have done it with a try catch, but Apple discourages that for typical errors.

Add a method that maintains the old API signature and just prints the error.

Add unit tests to verify changes.  This includes a new unhosted test target to avoid initialization done by our host app.  This test suite must run against simulator.

**Testing**

Check out branch.  Review and run unit tests in the Branch-SDK-Unhosted-Tests suite.

