### PR TITLE
Update BNCKeyChain kSecAttrAccessible value

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCKeyChain.m
+++ b/Branch-SDK/Branch-SDK/BNCKeyChain.m
@@ -180,7 +180,7 @@ CFStringRef SecCopyErrorMessageString(OSStatus status, void *reserved) {
 
     dictionary[(__bridge id)kSecValueData] = valueData;
     dictionary[(__bridge id)kSecAttrIsInvisible] = (__bridge id)kCFBooleanTrue;
-    dictionary[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
+    dictionary[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
 
     if (accessGroup.length) {
         dictionary[(__bridge id)kSecAttrAccessGroup] = accessGroup;


### PR DESCRIPTION
Same effect as previous setting, but disallows being restored (from backup) to a _different_ device.
More secure this way.

When adding these items to the Keychain, the App does not explicitly exclude the items from device backups, which will allow sensitive data to get exported to iTunes and iCloud backups.

Having sensitive data sent to iCloud exposes it to both Apple, Inc. and an attacker with the ability to compromise the user's iCloud account (similarly to the iCloud celebrity hack, described in http://en.wikipedia.org/wiki/August2014celebrityphotoleaks/).

Additionally, exporting data to iTunes backups allows an attacker with physical access to the device and its passcode to use the iTunes encrypted backup functionality to extract all the Keychain items (that are flagged for backups) from the device.

