### PR TITLE
Inteng 4827 handle non branch links properly

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -756,6 +756,10 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
 }
 
 - (BOOL)handleSchemeDeepLink_private:(NSURL*)url fromSelf:(BOOL)isFromSelf {
+    if (isFromSelf) {
+        [self resetUserSession];
+    }
+    
     BOOL handled = NO;
     self.preferenceHelper.referringURL = nil;
     if (url && ![url isEqual:[NSNull null]]) {
@@ -784,13 +788,10 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
         NSDictionary *params = [BNCEncodingUtils decodeQueryStringToDictionary:query];
         if (params[@"link_click_id"]) {
             handled = YES;
-            if (isFromSelf) {
-                [self resetUserSession];
-            }
             self.preferenceHelper.linkClickIdentifier = params[@"link_click_id"];
         }
     }
-    [self initUserSessionAndCallCallback:(self.initializationStatus != BNCInitStatusInitialized)];
+    [self initUserSessionAndCallCallback:YES];
     return handled;
 }
 


### PR DESCRIPTION
Branch now calls the callback when a non-branch URI scheme is called from the foreground.  This is more consistent behavior with android and universal links.

To test, from within a test app call a scheme with no parameters, the branch callback should be called with +non_branch_link and the calling scheme.


